### PR TITLE
Peu 905 v8

### DIFF
--- a/src/main/resources/index.jsp
+++ b/src/main/resources/index.jsp
@@ -11,9 +11,6 @@
 <%@page import="org.jahia.utils.DateUtils"%>
 <%@page import="org.apache.commons.lang.time.DurationFormatUtils"%>
 <%@ page import="org.jahia.modules.tools.modules.ModuleToolsHelper" %>
-<%@ page import="java.lang.management.ManagementFactory" %>
-<%@ page import="javax.management.ObjectName" %>
-<%@ page import="javax.management.MBeanServer" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core"  prefix="c" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <head>

--- a/src/main/resources/index.jsp
+++ b/src/main/resources/index.jsp
@@ -24,11 +24,10 @@
 <div style="position: absolute; right: 20px; top: 7px; font-size:1.0em;">
     <% if (Jahia.isEnterpriseEdition() && BundleUtils.getBundleBySymbolicName("tools-ee", null) != null) {
         if (Boolean.getBoolean("cluster.activated")) {
-            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-            ObjectName channel = new ObjectName("JGroupsReplication:type=channel,cluster=\"ehcache-jahia\"");
             %>
-            Current Node Id: <%=mBeanServer.getAttribute(channel, "address") %>
-            <% }
+            Current Node Id: <%= System.getProperty("cluster.node.serverId", "N/A") %>
+            <%
+        }
     } %>
     <br/>
     Uptime: <%= DurationFormatUtils.formatDurationWords(System.currentTimeMillis() - JahiaContextLoaderListener.getStartupTime(), true, true) %><br/>

--- a/src/main/resources/index.jsp
+++ b/src/main/resources/index.jsp
@@ -11,6 +11,9 @@
 <%@page import="org.jahia.utils.DateUtils"%>
 <%@page import="org.apache.commons.lang.time.DurationFormatUtils"%>
 <%@ page import="org.jahia.modules.tools.modules.ModuleToolsHelper" %>
+<%@ page import="java.lang.management.ManagementFactory" %>
+<%@ page import="javax.management.ObjectName" %>
+<%@ page import="javax.management.MBeanServer" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core"  prefix="c" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <head>
@@ -21,7 +24,19 @@
 </head>
 <body>
 <h1>Support Tools <span style="font-size:0.7em;">(<%= Jahia.getFullProductVersion() %>)</span></h1>
-<div style="position: absolute; right: 20px; top: 20px; font-size:1.0em;">Uptime: <%= DurationFormatUtils.formatDurationWords(System.currentTimeMillis() - JahiaContextLoaderListener.getStartupTime(), true, true) %><br/>Since: <%= new java.util.Date(JahiaContextLoaderListener.getStartupTime()) %></div>
+<div style="position: absolute; right: 20px; top: 7px; font-size:1.0em;">
+    <% if (Jahia.isEnterpriseEdition() && BundleUtils.getBundleBySymbolicName("tools-ee", null) != null) {
+        if (Boolean.getBoolean("cluster.activated")) {
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            ObjectName channel = new ObjectName("JGroupsReplication:type=channel,cluster=\"ehcache-jahia\"");
+            %>
+            Current Node Id: <%=mBeanServer.getAttribute(channel, "address") %>
+            <% }
+    } %>
+    <br/>
+    Uptime: <%= DurationFormatUtils.formatDurationWords(System.currentTimeMillis() - JahiaContextLoaderListener.getStartupTime(), true, true) %><br/>
+    Since: <%= new java.util.Date(JahiaContextLoaderListener.getStartupTime()) %>
+</div>
 <table width="100%" border="0">
     <tr>
         <td width="50%" valign="top">


### PR DESCRIPTION
## PEU-905 Add the current cluster node ID on main tool index page

https://support.jahia.com/browse/PEU-905

## Description

When cluster mode is enabled, it displays the current node ID on the main tool index page (on the top right, with the Uptime information)

## Checklist

Display the main tool index page on both cluster and non cluster mode, and check if the value is correct on all cluster nodes

I have considered the following implications of my change: 

- Only display current node ID on cluster mode