### PR TITLE
QA-13318: Add the current cluster node ID on main tool index page

### DIFF
--- a/src/main/resources/index.jsp
+++ b/src/main/resources/index.jsp
@@ -21,7 +21,18 @@
 </head>
 <body>
 <h1>Support Tools <span style="font-size:0.7em;">(<%= Jahia.getFullProductVersion() %>)</span></h1>
-<div style="position: absolute; right: 20px; top: 20px; font-size:1.0em;">Uptime: <%= DurationFormatUtils.formatDurationWords(System.currentTimeMillis() - JahiaContextLoaderListener.getStartupTime(), true, true) %><br/>Since: <%= new java.util.Date(JahiaContextLoaderListener.getStartupTime()) %></div>
+<div style="position: absolute; right: 20px; top: 7px; font-size:1.0em;">
+    <% if (Jahia.isEnterpriseEdition() && BundleUtils.getBundleBySymbolicName("tools-ee", null) != null) {
+        if (Boolean.getBoolean("cluster.activated")) {
+    %>
+    Current Node Id: <%= System.getProperty("cluster.node.serverId", "N/A") %>
+    <%
+            }
+        } %>
+    <br/>
+    Uptime: <%= DurationFormatUtils.formatDurationWords(System.currentTimeMillis() - JahiaContextLoaderListener.getStartupTime(), true, true) %><br/>
+    Since: <%= new java.util.Date(JahiaContextLoaderListener.getStartupTime()) %>
+</div>
 <table width="100%" border="0">
     <tr>
         <td width="50%" valign="top">


### PR DESCRIPTION
## QA-13318 Add the current cluster node ID on main tool index page

https://jira.jahia.org/browse/QA-13318

## Description

When cluster mode is enabled, it displays the current node ID on the main tool index page (on the top right, with the Uptime information)

## Checklist

Display the main tool index page on both cluster and non cluster mode, and check if the value is correct on all cluster nodes

I have considered the following implications of my change: 

- Only display current node ID on cluster mode