### PR TITLE
QA-14728 The API to retrieve the tools access token is not working properly

### DIFF
--- a/src/main/java/org/jahia/modules/tools/csrf/MissingTokenException.java
+++ b/src/main/java/org/jahia/modules/tools/csrf/MissingTokenException.java
@@ -24,7 +24,7 @@
 package org.jahia.modules.tools.csrf;
 
 /**
- * Dedicated exception to avoid masquareding of businnes exception inside a protocol one.
+ * Dedicated exception to avoid masquerading of a business exception inside a protocol one.
  *
  * @author Jerome Blanchard
  */

--- a/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
+++ b/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
@@ -66,6 +66,7 @@ public class ToolsAccessTokenFilter extends AbstractServletFilter {
                     response.setStatus(HttpServletResponse.SC_OK);
                     out.print(body);
                     out.flush();
+                    //return here to avoid calling filter chain and cause an exception because writing in an already flushed response writer
                     return;
                 }
             }

--- a/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
+++ b/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
@@ -54,6 +54,8 @@ public class ToolsAccessTokenFilter extends AbstractServletFilter {
                 }
             } else {
                 String token = generateAndStoreToken(request);
+                //Token generation is performed if the request is a POST on the specific path, in that case filter chain is not called
+                //a better approach would be to use a dedicated endpoint for token generation
                 if (request.getMethod().equals(TOKEN_METHOD) && request.getRequestURI().endsWith(TOKEN_URI)) {
                     HttpServletResponse response = (HttpServletResponse) servletResponse;
                     String body = "{\"token\":\"" + token + "\"}";


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-14728

## Description

Every time such a token is retrieved, an error is printed out in the logs, and the http response is considered as an error by some HTTP clients (even though it comes with the http code 200).

## Tests

The following are included in this PR

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

N/A