### PR TITLE
BACKLOG-22357: Tool to identify import packages / runtime dependencies

### DIFF
--- a/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
+++ b/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class ToolsAccessTokenFilter extends AbstractServletFilter {
     private static final String CSRF_TOKENS_ATTR = "toolAccessTokens";
@@ -46,41 +45,34 @@ public class ToolsAccessTokenFilter extends AbstractServletFilter {
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         if (request.getPathInfo() != null && TOOLS_REGEXP.matcher(request.getPathInfo()).matches()) {
-            if (!servletRequest.getParameterMap().isEmpty()) {
-                try {
-                    validateToken(request);
-                } catch (MissingTokenException e) {
-                    throw new ServletException(e.getMessage());
-                }
+            if (servletRequest.getParameterMap().size() > 0) {
+                validateToken(request);
             } else {
                 String token = generateAndStoreToken(request);
+
                 if (request.getMethod().equals(TOKEN_METHOD) && request.getRequestURI().endsWith(TOKEN_URI)) {
                     HttpServletResponse response = (HttpServletResponse) servletResponse;
-                    String body = "{\"token\":\"" + token + "\"}";
                     PrintWriter out = response.getWriter();
                     response.setContentType(TOKEN_CONTENT_TYPE);
-                    response.setContentLength(body.length());
                     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-                    response.setStatus(HttpServletResponse.SC_OK);
-                    out.print(body);
+                    out.print("{\"token\":\"" + token + "\"}");
                     out.flush();
-                    return;
                 }
             }
         }
+
         filterChain.doFilter(servletRequest, servletResponse);
     }
 
     @SuppressWarnings("unchecked")
-    private void validateToken(HttpServletRequest httpReq) throws MissingTokenException {
+    private void validateToken(HttpServletRequest httpReq) throws ServletException {
         if (SettingsBean.getInstance().isDevelopmentMode()) {
             return;
         }
         String token = httpReq.getParameter(CSRF_TOKEN_ATTR);
 
         if (token == null || getCache(httpReq).get(token) == null || getCache(httpReq).get(token) < (System.currentTimeMillis() - tokenExpiration * 60L * 1000L)) {
-            throw new MissingTokenException("Missing token: " + httpReq.getRequestURL() + (StringUtils.isNotEmpty(httpReq.getQueryString()) ?
-                    ("?" + httpReq.getQueryString()) : ""));
+            throw new ServletException("Missing token: " + httpReq.getRequestURL() + (StringUtils.isNotEmpty(httpReq.getQueryString()) ? ("?" + httpReq.getQueryString()) : ""));
         }
 
         // keep same token
@@ -93,10 +85,6 @@ public class ToolsAccessTokenFilter extends AbstractServletFilter {
         String token = UUID.randomUUID().toString();
         HashMap<String, Long> tokens = getCache(httpReq);
         tokens.put(token, System.currentTimeMillis());
-
-        //Purge stale tokens
-        tokens = tokens.entrySet().stream().filter(e -> e.getValue() > (System.currentTimeMillis() - tokenExpiration * 60L * 1000L))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, HashMap::new));
 
         if (tokens.size() > MAX_TOKENS) {
             tokens.remove(tokens.entrySet().stream().min(Map.Entry.comparingByValue()).orElseThrow(ArrayIndexOutOfBoundsException::new).getKey());

--- a/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
+++ b/src/main/java/org/jahia/modules/tools/csrf/ToolsAccessTokenFilter.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class ToolsAccessTokenFilter extends AbstractServletFilter {
     private static final String CSRF_TOKENS_ATTR = "toolAccessTokens";
@@ -45,34 +46,41 @@ public class ToolsAccessTokenFilter extends AbstractServletFilter {
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         if (request.getPathInfo() != null && TOOLS_REGEXP.matcher(request.getPathInfo()).matches()) {
-            if (servletRequest.getParameterMap().size() > 0) {
-                validateToken(request);
+            if (!servletRequest.getParameterMap().isEmpty()) {
+                try {
+                    validateToken(request);
+                } catch (MissingTokenException e) {
+                    throw new ServletException(e.getMessage());
+                }
             } else {
                 String token = generateAndStoreToken(request);
-
                 if (request.getMethod().equals(TOKEN_METHOD) && request.getRequestURI().endsWith(TOKEN_URI)) {
                     HttpServletResponse response = (HttpServletResponse) servletResponse;
+                    String body = "{\"token\":\"" + token + "\"}";
                     PrintWriter out = response.getWriter();
                     response.setContentType(TOKEN_CONTENT_TYPE);
+                    response.setContentLength(body.length());
                     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-                    out.print("{\"token\":\"" + token + "\"}");
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    out.print(body);
                     out.flush();
+                    return;
                 }
             }
         }
-
         filterChain.doFilter(servletRequest, servletResponse);
     }
 
     @SuppressWarnings("unchecked")
-    private void validateToken(HttpServletRequest httpReq) throws ServletException {
+    private void validateToken(HttpServletRequest httpReq) throws MissingTokenException {
         if (SettingsBean.getInstance().isDevelopmentMode()) {
             return;
         }
         String token = httpReq.getParameter(CSRF_TOKEN_ATTR);
 
         if (token == null || getCache(httpReq).get(token) == null || getCache(httpReq).get(token) < (System.currentTimeMillis() - tokenExpiration * 60L * 1000L)) {
-            throw new ServletException("Missing token: " + httpReq.getRequestURL() + (StringUtils.isNotEmpty(httpReq.getQueryString()) ? ("?" + httpReq.getQueryString()) : ""));
+            throw new MissingTokenException("Missing token: " + httpReq.getRequestURL() + (StringUtils.isNotEmpty(httpReq.getQueryString()) ?
+                    ("?" + httpReq.getQueryString()) : ""));
         }
 
         // keep same token
@@ -85,6 +93,10 @@ public class ToolsAccessTokenFilter extends AbstractServletFilter {
         String token = UUID.randomUUID().toString();
         HashMap<String, Long> tokens = getCache(httpReq);
         tokens.put(token, System.currentTimeMillis());
+
+        //Purge stale tokens
+        tokens = tokens.entrySet().stream().filter(e -> e.getValue() > (System.currentTimeMillis() - tokenExpiration * 60L * 1000L))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, HashMap::new));
 
         if (tokens.size() > MAX_TOKENS) {
             tokens.remove(tokens.entrySet().stream().min(Map.Entry.comparingByValue()).orElseThrow(ArrayIndexOutOfBoundsException::new).getKey());

--- a/src/main/java/org/jahia/modules/tools/gql/admin/ToolsGraphQL.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/ToolsGraphQL.java
@@ -17,12 +17,7 @@ package org.jahia.modules.tools.gql.admin;
 
 import graphql.annotations.annotationTypes.*;
 import org.jahia.modules.graphql.provider.dxm.util.GqlUtils;
-import org.jahia.modules.tools.gql.admin.osgi.BundleResultEntry;
-import org.jahia.modules.tools.gql.admin.osgi.FindExportPackage;
-import org.jahia.modules.tools.gql.admin.osgi.OSGIPackageHeaderChecker;
-import org.jahia.modules.tools.gql.admin.osgi.FindImportPackage;
-
-import java.util.List;
+import org.jahia.modules.tools.gql.admin.osgi.*;
 
 @GraphQLName("AdminTools")
 @GraphQLDescription("Jahia admin tools")
@@ -49,13 +44,13 @@ public class ToolsGraphQL {
 
     @GraphQLField
     @GraphQLDescription("Will search packages in bundles applying name filter (regexp) in the exported and/or imported ones")
-    public List<BundleResultEntry> packages(
+    public FindPackageResult findPackages(
             @GraphQLName("filter") @GraphQLDescription("Package name should match the filter (regexp)") String filter,
+            @GraphQLName("version") @GraphQLDescription("Package version should match") String version,
             @GraphQLName("duplicates") @GraphQLDescription("Only return if matched packages contains duplicates") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean duplicates,
             @GraphQLName("imports") @GraphQLDescription("Only search for package matching in bundle imports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean imports,
             @GraphQLName("exports") @GraphQLDescription("Only search for package matching in bundle exports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean exports
     ) {
-        //TODO add version filter
-        return OSGIPackageHeaderChecker.findPackages(filter, duplicates, imports, exports);
+        return new FindPackageResult(OSGIPackageHeaderChecker.findPackages(filter, version, duplicates, imports, exports));
     }
 }

--- a/src/main/java/org/jahia/modules/tools/gql/admin/ToolsGraphQL.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/ToolsGraphQL.java
@@ -49,8 +49,9 @@ public class ToolsGraphQL {
             @GraphQLName("version") @GraphQLDescription("Package version should match") String version,
             @GraphQLName("duplicates") @GraphQLDescription("Only return if matched packages contains duplicates") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean duplicates,
             @GraphQLName("imports") @GraphQLDescription("Only search for package matching in bundle imports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean imports,
-            @GraphQLName("exports") @GraphQLDescription("Only search for package matching in bundle exports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean exports
+            @GraphQLName("exports") @GraphQLDescription("Only search for package matching in bundle exports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean exports,
+            @GraphQLName("subtree") @GraphQLDescription("Include for each package (import/export) other bundle usage") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean subtree
     ) {
-        return new FindPackageResult(OSGIPackageHeaderChecker.findPackages(filter, version, duplicates, imports, exports));
+        return new FindPackageResult(OSGIPackageHeaderChecker.findPackages(filter, version, duplicates, imports, exports, subtree));
     }
 }

--- a/src/main/java/org/jahia/modules/tools/gql/admin/ToolsGraphQL.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/ToolsGraphQL.java
@@ -17,10 +17,12 @@ package org.jahia.modules.tools.gql.admin;
 
 import graphql.annotations.annotationTypes.*;
 import org.jahia.modules.graphql.provider.dxm.util.GqlUtils;
+import org.jahia.modules.tools.gql.admin.osgi.BundleResultEntry;
 import org.jahia.modules.tools.gql.admin.osgi.FindExportPackage;
 import org.jahia.modules.tools.gql.admin.osgi.OSGIPackageHeaderChecker;
 import org.jahia.modules.tools.gql.admin.osgi.FindImportPackage;
 
+import java.util.List;
 
 @GraphQLName("AdminTools")
 @GraphQLDescription("Jahia admin tools")
@@ -30,7 +32,7 @@ public class ToolsGraphQL {
     public FindImportPackage findMatchingImportPackages(
             @GraphQLName("RegExp") @GraphQLDescription("will return only import-package matching the RegExp") String regExp,
             @GraphQLName("version") @GraphQLDescription("will return only import-package matching the given version") String version,
-            @GraphQLName("versionMissing") @GraphQLDescription("will return only import-package with no version range limitations") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean versionMissing
+            @GraphQLName("versionMissing") @GraphQLDescription("will return only import-package matching the given version") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean versionMissing
     ) {
         return OSGIPackageHeaderChecker.findImportPackages(regExp, version, versionMissing);
     }
@@ -39,8 +41,21 @@ public class ToolsGraphQL {
     @GraphQLDescription("Will return all the duplicate export packages and the bundles that export them")
     public FindExportPackage findMatchingExportPackages(
             @GraphQLName("RegExp") @GraphQLDescription("will return only export-package matching the RegExp") String regExp,
-            @GraphQLName("duplicates") @GraphQLDescription("will return only export-package found multiple times for a same package name") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean duplicates
+            @GraphQLName("duplicates") @GraphQLDescription("will return only export-package found multiple times for a same package name") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean duplicates,
+            @GraphQLName("location") @GraphQLDescription("will return the list of files where package export has been found") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean location
     ) {
-        return OSGIPackageHeaderChecker.findExportPackages(regExp, duplicates);
+        return OSGIPackageHeaderChecker.findExportPackages(regExp, duplicates, location);
+    }
+
+    @GraphQLField
+    @GraphQLDescription("Will search packages in bundles applying name filter (regexp) in the exported and/or imported ones")
+    public List<BundleResultEntry> packages(
+            @GraphQLName("filter") @GraphQLDescription("Package name should match the filter (regexp)") String filter,
+            @GraphQLName("duplicates") @GraphQLDescription("Only return if matched packages contains duplicates") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) boolean duplicates,
+            @GraphQLName("imports") @GraphQLDescription("Only search for package matching in bundle imports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean imports,
+            @GraphQLName("exports") @GraphQLDescription("Only search for package matching in bundle exports") @GraphQLDefaultValue(GqlUtils.SupplierTrue.class) boolean exports
+    ) {
+        //TODO add version filter
+        return OSGIPackageHeaderChecker.findPackages(filter, duplicates, imports, exports);
     }
 }

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
@@ -140,18 +140,18 @@ public class BundleResultEntry {
         @GraphQLDescription("Import packages of the bundle in a compact form.")
         public String[] getCompact() {
             return imports.stream().map(i -> i.getName().concat((StringUtils.isNotEmpty(i.getVersion()))?
-                    ",".concat(i.getVersion()):"")).toArray(String[]::new);
+                    ",".concat(i.getVersion()):"")).sorted().toArray(String[]::new);
         }
 
         @GraphQLField
         @GraphQLName("detailed")
         @GraphQLDescription("Import packages of the bundle in a detailed form.")
         public List<BundleImport> getDetailed() {
-            return imports;
+            return imports.stream().sorted().collect(Collectors.toList());
         }
     }
 
-    public static class BundleImport {
+    public static class BundleImport implements Comparable<BundleImport> {
 
         private final String clause;
         private final String name;
@@ -167,6 +167,11 @@ public class BundleResultEntry {
 
         public void addExports(Set<BundleResultEntry> bundles) {
             this.exports.addAll(bundles);
+        }
+
+        @Override
+        public int compareTo(BundleImport bundle) {
+            return Comparator.comparing(BundleImport::getName).thenComparing(BundleImport::getVersion).compare(this, bundle);
         }
 
         @GraphQLField
@@ -231,18 +236,18 @@ public class BundleResultEntry {
         @GraphQLDescription("Export packages of the bundle in a compact form.")
         public String[] getCompact() {
             return exports.stream().map(e -> e.getName().concat((StringUtils.isNotEmpty(e.getVersion()))?
-                    ",".concat(e.getVersion()):"")).toArray(String[]::new);
+                    ",".concat(e.getVersion()):"")).sorted().toArray(String[]::new);
         }
 
         @GraphQLField
         @GraphQLName("detailed")
         @GraphQLDescription("Export packages of the bundle in a detailed form.")
         public List<BundleExport> getDetailed() {
-            return exports;
+            return exports.stream().sorted().collect(Collectors.toList());
         }
     }
 
-    public static class BundleExport {
+    public static class BundleExport implements Comparable<BundleExport> {
 
         private final String clause;
         private final String name;
@@ -260,6 +265,11 @@ public class BundleResultEntry {
 
         public void addImports(Set<BundleResultEntry> bundles) {
             this.imports.addAll(bundles);
+        }
+
+        @Override
+        public int compareTo(BundleExport bundle) {
+            return Comparator.comparing(BundleExport::getName).thenComparing(BundleExport::getVersion).compare(this, bundle);
         }
 
         @GraphQLField

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
@@ -20,15 +20,17 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.osgi.framework.Bundle;
 
-/**
- * An abstract class that provide basic bundle information for a GQL result that would involve bundle.
- * Can be implemented to automatically provide bundle GQL fields.
- */
-public abstract class BundleResultEntry {
+import java.util.ArrayList;
+import java.util.List;
+
+public class BundleResultEntry {
+    private final long bundleId;
     private final String bundleName;
     private final String bundleSymbolicName;
     private final String bundleDisplayName;
-    private final long bundleId;
+    private final List<BundleResultImport> bundleImports = new ArrayList<>();
+    private final List<BundleResultExport> bundleExports = new ArrayList<>();
+
 
     public BundleResultEntry(Bundle bundle) {
         this.bundleName = bundle.getHeaders().get("Bundle-Name");
@@ -37,6 +39,16 @@ public abstract class BundleResultEntry {
                 bundleName + " (" + bundleSymbolicName + ")" :
                 bundleSymbolicName;
         this.bundleId = bundle.getBundleId();
+    }
+
+    public BundleResultEntry(long bundleId, String bundleName, String bundleSymbolicName, String bundleDisplayName,
+            List<BundleResultImport> bundleImports, List<BundleResultExport> bundleExports) {
+        this.bundleId = bundleId;
+        this.bundleName = bundleName;
+        this.bundleSymbolicName = bundleSymbolicName;
+        this.bundleDisplayName = bundleDisplayName;
+        this.bundleImports.addAll(bundleImports);
+        this.bundleExports.addAll(bundleExports);
     }
 
     @GraphQLField
@@ -65,5 +77,104 @@ public abstract class BundleResultEntry {
     @GraphQLDescription("ID of the bundle.")
     public long getBundleId() {
         return bundleId;
+    }
+
+    @GraphQLField
+    @GraphQLName("bundleImports")
+    @GraphQLDescription("Imports of the bundle.")
+    public List<BundleResultImport> getBundleImports() {
+        return bundleImports;
+    }
+
+    @GraphQLField
+    @GraphQLName("bundleExports")
+    @GraphQLDescription("Exports of the bundle.")
+    public List<BundleResultExport> getBundleExports() {
+        return bundleExports;
+    }
+
+    public void addImport(String clause, String name, String version) {
+        bundleImports.add(new BundleResultImport(clause, name, version));
+    }
+
+    public void addExport(String clause, String name, String version, List<String> uses) {
+        bundleExports.add(new BundleResultExport(clause, name, version, uses));
+    }
+
+    public static class BundleResultImport {
+
+        private final String clause;
+        private final String name;
+        private final String version;
+
+        public BundleResultImport(String clause, String name, String version) {
+            this.clause = clause;
+            this.name = name;
+            this.version = version;
+        }
+
+        @GraphQLField
+        @GraphQLName("importPackageClause")
+        @GraphQLDescription("Display full import clause.")
+        public String getClause() {
+            return clause;
+        }
+
+        @GraphQLField
+        @GraphQLName("importPackageName")
+        @GraphQLDescription("Display import package name.")
+        public String getName() {
+            return name;
+        }
+
+        @GraphQLField
+        @GraphQLName("importPackageVersion")
+        @GraphQLDescription("Display import package version.")
+        public String getVersion() {
+            return version;
+        }
+    }
+
+    public static class BundleResultExport {
+
+        private final String clause;
+        private final String name;
+        private final String version;
+        private final List<String> uses;
+
+        public BundleResultExport(String clause, String name, String version, List<String> uses) {
+            this.clause = clause;
+            this.name = name;
+            this.version = version;
+            this.uses = uses;
+        }
+
+        @GraphQLField
+        @GraphQLName("exportPackageClause")
+        @GraphQLDescription("Display full export clause.")
+        public String getClause() {
+            return clause;
+        }
+
+        @GraphQLField
+        @GraphQLName("exportPackageName")
+        @GraphQLDescription("Display export package name.")
+        public String getName() {
+            return name;
+        }
+
+        @GraphQLField
+        @GraphQLName("exportPackageVersion")
+        @GraphQLDescription("Display export package version.")
+        public String getVersion() {
+            return version;
+        }
+
+        @GraphQLField
+        @GraphQLName("exportPackageUses")
+        @GraphQLDescription("Display export package uses.")
+        public List<String> getUses() {
+            return uses;
+            }
     }
 }

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/FindPackageResult.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/FindPackageResult.java
@@ -1,0 +1,79 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2024 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.tools.gql.admin.osgi;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+import java.util.List;
+
+/**
+ * Short description of the class
+ *
+ * @author Jerome Blanchard
+ */
+@GraphQLName("FindPackage")
+@GraphQLDescription("Result of the search package inspector operation.")
+public class FindPackageResult {
+
+    int bundlesCount = 0;
+    int importPackageCount = 0;
+    int exportPackageCount = 0;
+
+    List<BundleResultEntry> results;
+
+    public FindPackageResult(List<BundleResultEntry> results) {
+        this.results = results;
+    }
+
+    @GraphQLField
+    @GraphQLName("bundlesCount")
+    @GraphQLDescription("Total number of bundles containing matching packages.")
+    public int getBundlesCount() {
+        return results.size();
+    }
+
+    @GraphQLField
+    @GraphQLName("importPackageCount")
+    @GraphQLDescription("Total number of matching importPackages")
+    public int getImportPackageCount() {
+        return results.stream().mapToInt(b -> b.getImports().size()).sum();
+    }
+
+    @GraphQLField
+    @GraphQLName("exportPackageCount")
+    @GraphQLDescription("Total number of matching exportPackages")
+    public int getExportPackageCount() {
+        return results.stream().mapToInt(b -> b.getExports().size()).sum();
+    }
+
+    @GraphQLField
+    @GraphQLName("results")
+    @GraphQLDescription("Bundles found with matching packages")
+    public List<BundleResultEntry> getResults() {
+        return results;
+    }
+
+}

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
@@ -157,7 +157,6 @@ public class OSGIPackageHeaderChecker {
         if (duplicates) {
             results.forEach(b -> b.getExports().keepDuplicateNamesOnly());
             results.forEach(b -> b.getImports().keepDuplicateNamesOnly());
-            results = results.stream().filter(b -> b.getImports().size() > 1 || b.getExports().size() > 1).collect(Collectors.toList());
         }
         //Remove the bundles that have no more matching import or export packages
         results.removeIf(b -> b.getImports().size() == 0 && b.getExports().size() == 0);

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
@@ -137,8 +137,8 @@ public class OSGIPackageHeaderChecker {
         return results;
     }
 
-    public static List<BundleResultEntry> findPackages(String filter, String version, boolean imports, boolean exports,
-            boolean duplicates) {
+    public static List<BundleResultEntry> findPackages(String filter, String version, boolean duplicates, boolean imports,
+            boolean exports, boolean subtree) {
         final List<BundleResultEntry> bundles = loadBundles();
         //Filter bundles that have only matching import or export packages depending on options set
         List<BundleResultEntry> results = bundles.stream().filter(b ->
@@ -161,8 +161,14 @@ public class OSGIPackageHeaderChecker {
         //Remove the bundles that have no more matching import or export packages
         results.removeIf(b -> b.getImports().size() == 0 && b.getExports().size() == 0);
         //Populate the imports and exports with the bundles that export or import the package
-        results.forEach(b -> b.getImports().getDetailed().forEach(p -> p.addExports(bundles.stream().filter(b2 -> b2.getExports().getDetailed().stream().anyMatch(p2 -> p2.getName().equals(p.getName()))).collect(Collectors.toSet()))));
-        results.forEach(b -> b.getExports().getDetailed().forEach(p -> p.addImports(bundles.stream().filter(b2 -> b2.getImports().getDetailed().stream().anyMatch(p2 -> p2.getName().equals(p.getName()))).collect(Collectors.toSet()))));
+        if (subtree) {
+            results.forEach(b -> b.getImports().getDetailed().forEach(p -> p.addExports(
+                    bundles.stream().filter(b2 -> b2.getExports().getDetailed().stream().anyMatch(p2 -> p2.getName().equals(p.getName())))
+                            .collect(Collectors.toSet()))));
+            results.forEach(b -> b.getExports().getDetailed().forEach(p -> p.addImports(
+                    bundles.stream().filter(b2 -> b2.getImports().getDetailed().stream().anyMatch(p2 -> p2.getName().equals(p.getName())))
+                            .collect(Collectors.toSet()))));
+        }
         return results;
     }
 

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
@@ -140,17 +140,17 @@ public class OSGIPackageHeaderChecker {
     public static List<BundleResultEntry> findPackages(String filter, String version, boolean imports, boolean exports,
             boolean duplicates) {
         List<BundleResultEntry> bundles = loadBundles();
-        List<BundleResultEntry> results =  bundles.stream().filter(b ->
+        List<BundleResultEntry> results = bundles.stream().filter(b ->
                 (imports && b.getImports().getDetailed().stream().anyMatch(p -> p.getName().matches(filter))) ||
                 (exports && b.getExports().getDetailed().stream().anyMatch(p -> p.getName().matches(filter))))
                 .map(e -> new BundleResultEntry(e.getBundleId(), e.getBundleName(), e.getBundleSymbolicName(), e.getBundleDisplayName(),
-                        e.getImports().getDetailed().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList()),
-                        e.getExports().getDetailed().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList())))
+                        (imports)?e.getImports().getDetailed().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList()):Collections.emptyList(),
+                        (exports)?e.getExports().getDetailed().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList()):Collections.emptyList()))
                 .collect(Collectors.toList());
         if (duplicates) {
-            //remove all distinct of all list
+            results = results.stream().filter(b -> b.getImports().size() > 1 || b.getExports().size() > 1).collect(Collectors.toList());
         }
-        return results;
+        return results.stream().filter(b -> b.getImports().size() > 0 || b.getExports().size() > 0).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/OSGIPackageHeaderChecker.java
@@ -137,18 +137,20 @@ public class OSGIPackageHeaderChecker {
         return results;
     }
 
-    public static List<BundleResultEntry> findPackages(String filter, boolean duplicates, boolean imports, boolean exports) {
+    public static List<BundleResultEntry> findPackages(String filter, String version, boolean imports, boolean exports,
+            boolean duplicates) {
         List<BundleResultEntry> bundles = loadBundles();
-        List<BundleResultEntry> result = bundles.stream().filter(b ->
-                (imports && b.getBundleImports().stream().filter(p -> p.getName().matches(filter)).count() > ((duplicates) ? 1 : 0)) ||
-                (exports && b.getBundleExports().stream().filter(p -> p.getName().matches(filter)).count() > ((duplicates) ? 1 : 0))).map(
-                        e -> new BundleResultEntry(e.getBundleId(), e.getBundleName(), e.getBundleSymbolicName(),
-                                e.getBundleDisplayName(), (imports)?
-                                e.getBundleImports().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList()):
-                                Collections.emptyList(), (exports)?
-                                e.getBundleExports().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList()):
-                                Collections.emptyList())).collect(Collectors.toList());
-        return result;
+        List<BundleResultEntry> results =  bundles.stream().filter(b ->
+                (imports && b.getImports().getDetailed().stream().anyMatch(p -> p.getName().matches(filter))) ||
+                (exports && b.getExports().getDetailed().stream().anyMatch(p -> p.getName().matches(filter))))
+                .map(e -> new BundleResultEntry(e.getBundleId(), e.getBundleName(), e.getBundleSymbolicName(), e.getBundleDisplayName(),
+                        e.getImports().getDetailed().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList()),
+                        e.getExports().getDetailed().stream().filter(p -> p.getName().matches(filter)).collect(Collectors.toList())))
+                .collect(Collectors.toList());
+        if (duplicates) {
+            //remove all distinct of all list
+        }
+        return results;
     }
 
     /**


### PR DESCRIPTION
## JIRA

Improvement over existing ticket : 
https://jira.jahia.org/browse/BACKLOG-22357

## Description

Improve the tool to combine export/import in the same result and have also a two level inspection :
 - if a package is exported (or imported), you can see what bundle imports that package (or export as opposite)
A compact view of result is also provided to ease reading and mapping with configuration files
A unique global lookup is done to ensure fast response time on large responses with multi level inclusions

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
