### PR TITLE
BACKLOG-23172: Remove "bundle" prefix for fields

### DIFF
--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
@@ -15,6 +15,7 @@
  */
 package org.jahia.modules.tools.gql.admin.osgi;
 
+import graphql.annotations.annotationTypes.GraphQLDeprecate;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
@@ -25,45 +26,82 @@ import org.osgi.framework.Bundle;
  * Can be implemented to automatically provide bundle GQL fields.
  */
 public abstract class BundleResultEntry {
-    private final String bundleName;
-    private final String bundleSymbolicName;
-    private final String bundleDisplayName;
-    private final long bundleId;
+    private final String name;
+    private final String symbolicName;
+    private final String displayName;
+    private final long id;
 
     public BundleResultEntry(Bundle bundle) {
-        this.bundleName = bundle.getHeaders().get("Bundle-Name");
-        this.bundleSymbolicName = bundle.getSymbolicName();
-        this.bundleDisplayName = bundleName != null ?
-                bundleName + " (" + bundleSymbolicName + ")" :
-                bundleSymbolicName;
-        this.bundleId = bundle.getBundleId();
+        this.name = bundle.getHeaders().get("Bundle-Name");
+        this.symbolicName = bundle.getSymbolicName();
+        this.displayName = name != null ?
+                name + " (" + symbolicName + ")" :
+                symbolicName;
+        this.id = bundle.getBundleId();
+    }
+
+    @GraphQLField
+    @GraphQLName("name")
+    @GraphQLDescription("Name of the bundle.")
+    public String getName() {
+        return name;
     }
 
     @GraphQLField
     @GraphQLName("bundleName")
     @GraphQLDescription("Name of the bundle.")
+    @GraphQLDeprecate("Use name instead")
+    @Deprecated
     public String getBundleName() {
-        return bundleName;
+        return name;
+    }
+
+    @GraphQLField
+    @GraphQLName("symbolicName")
+    @GraphQLDescription("Symbolic name of the bundle.")
+    public String getSymbolicName() {
+        return symbolicName;
     }
 
     @GraphQLField
     @GraphQLName("bundleSymbolicName")
     @GraphQLDescription("Symbolic name of the bundle.")
+    @GraphQLDeprecate("Use symbolicName instead")
+    @Deprecated
     public String getBundleSymbolicName() {
-        return bundleSymbolicName;
+        return symbolicName;
+    }
+
+    @GraphQLField
+    @GraphQLName("displayName")
+    @GraphQLDescription("Display name of the bundle.")
+    public String getDisplayName() {
+        return displayName;
     }
 
     @GraphQLField
     @GraphQLName("bundleDisplayName")
     @GraphQLDescription("Display name of the bundle.")
+    @GraphQLDeprecate("Use displayName instead")
+    @Deprecated
     public String getBundleDisplayName() {
-        return bundleDisplayName;
+        return displayName;
+    }
+
+    @GraphQLField
+    @GraphQLName("id")
+    @GraphQLDescription("ID of the bundle.")
+    public long getId() {
+        return id;
     }
 
     @GraphQLField
     @GraphQLName("bundleId")
     @GraphQLDescription("ID of the bundle.")
+    @GraphQLDeprecate("Use id instead")
+    @Deprecated
     public long getBundleId() {
-        return bundleId;
+        return id;
     }
+
 }

--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/ExportPackages.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/ExportPackages.java
@@ -52,7 +52,7 @@ public class ExportPackages {
     @GraphQLDescription("Flat list of exported packages")
     public List<String> getMatchingPackages() {
         return exportPackages.stream().map(
-                (BundleWithExportPackage entry) -> entry.getPackage() + " EXPOSED BY " + entry.getBundleDisplayName()
+                (BundleWithExportPackage entry) -> entry.getPackage() + " EXPOSED BY " + entry.getDisplayName()
         ).collect(Collectors.toList());
     }
 

--- a/src/main/resources/importPackageChecker.jsp
+++ b/src/main/resources/importPackageChecker.jsp
@@ -69,10 +69,10 @@
             <ul>
                 <c:forEach items="${result.bundles}" var="entry">
                     <li>
-                        <a href="<c:url value='/tools/osgi/console/bundles/${entry.bundleId}'/>" title="See details">
-                            [${entry.bundleId}]
+                        <a href="<c:url value='/tools/osgi/console/bundles/${entry.id}'/>" title="See details">
+                            [${entry.id}]
                         </a>
-                        <strong>${entry.bundleDisplayName} [${entry.bundleId}]</strong>
+                        <strong>${entry.displayName} [${entry.id}]</strong>
 
                         <ul>
                             <c:forEach items="${entry.matchingImportedPackage}" var="importedPackage">

--- a/tests/cypress/e2e/api/bundles.spec.ts
+++ b/tests/cypress/e2e/api/bundles.spec.ts
@@ -2,7 +2,7 @@ import {getBundles, Status} from '../../support/gql';
 import {waitUntilSAMStatusGreen} from '@jahia/cypress';
 
 function testBundle(bundles, bundleName: string, version: string, status: string) {
-    const bundle = bundles.find(b => b.bundleSymbolicName === bundleName);
+    const bundle = bundles.find(b => b.symbolicName === bundleName);
     console.log('testing bundle', bundle);
     const bundleImport = bundle.dependencies.find(dep => dep.name === 'org.external.modules.provider');
     expect(bundleImport.type).to.eq('IMPORT_PACKAGE');
@@ -13,7 +13,7 @@ function testBundle(bundles, bundleName: string, version: string, status: string
 }
 
 function testBundleAndDependency(bundles, bundleName: string, dependsIsOptional: boolean, dependsVersion: string, dependsStatus: string) {
-    const bundle = bundles.find(b => b.bundleSymbolicName === bundleName);
+    const bundle = bundles.find(b => b.symbolicName === bundleName);
     console.log('testing bundle and dependency', bundle);
     const bundleImport = bundle.dependencies.find(dep => dep.name === 'org.external.modules.provider');
     expect(bundleImport.type).to.eq('IMPORT_PACKAGE');
@@ -144,7 +144,7 @@ describe('Dependencies tool test', () => {
                     'module-dependant-case33'
                 ];
                 expectedBundles.forEach(bundleName => {
-                    const bundleExists = result.data.admin.tools.bundles.some(b => b.bundleSymbolicName === bundleName);
+                    const bundleExists = result.data.admin.tools.bundles.some(b => b.symbolicName === bundleName);
                     expect(bundleExists).to.be.true;
                 });
             });

--- a/tests/cypress/fixtures/getBundles.graphql
+++ b/tests/cypress/fixtures/getBundles.graphql
@@ -2,9 +2,9 @@ query($nameRegExp: String, $areModules: Boolean, $withUnsupportedDependenciesOnl
     admin {
         tools {
             bundles(nameRegExp: $nameRegExp, areModules: $areModules, withUnsupportedDependenciesOnly: $withUnsupportedDependenciesOnly) {
-                bundleDisplayName,
-                bundleName,
-                bundleSymbolicName
+                displayName,
+                name,
+                symbolicName
                 dependencies(supported: $supported, statuses: $statuses) {
                     type,
                     name,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23172

## Description

Remove the "bundle" prefix for the fields of 3 GraphQL APIs (`findMatchingImportPackages`, `findMatchingExportPackages` and `bundles`):
- `bundleName` -> `name`
- `bundleSymbolicName` -> `symbolicName`
- `bundleDisplayName` -> `displayName`
- `bundleId` -> `id`

The previous fields are marked as deprecated to remain backward-compatible.
