### PR TITLE
BACKLOG-23172: Add 'version' field for the bundles

### DIFF
--- a/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
+++ b/src/main/java/org/jahia/modules/tools/gql/admin/osgi/BundleResultEntry.java
@@ -20,6 +20,7 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
 
 /**
  * An abstract class that provide basic bundle information for a GQL result that would involve bundle.
@@ -30,6 +31,7 @@ public abstract class BundleResultEntry {
     private final String symbolicName;
     private final String displayName;
     private final long id;
+    private final Version version;
 
     public BundleResultEntry(Bundle bundle) {
         this.name = bundle.getHeaders().get("Bundle-Name");
@@ -38,6 +40,7 @@ public abstract class BundleResultEntry {
                 name + " (" + symbolicName + ")" :
                 symbolicName;
         this.id = bundle.getBundleId();
+        this.version = bundle.getVersion();
     }
 
     @GraphQLField
@@ -104,4 +107,10 @@ public abstract class BundleResultEntry {
         return id;
     }
 
+    @GraphQLField
+    @GraphQLName("version")
+    @GraphQLDescription("Version of the bundle.")
+    public String getVersion() {
+        return version.toString();
+    }
 }

--- a/tests/cypress/e2e/api/bundles.spec.ts
+++ b/tests/cypress/e2e/api/bundles.spec.ts
@@ -229,5 +229,20 @@ describe('Dependencies tool test', () => {
                 expect(result.errors[0].message).to.eq('At least one status must be provided (via the \'statuses\' parameter)');
             });
         });
+        it('Test bundle fields are present', () => {
+            getBundles({nameRegExp: 'module-provider'}).should(result => {
+                console.log('result', result);
+                expect(result).to.have.property('data');
+                expect(result.data).to.have.property('admin');
+                expect(result.data.admin).to.have.property('tools');
+                expect(result.data.admin.tools).to.have.property('bundles');
+                expect(result.data.admin.tools.bundles).to.have.length(1);
+                const bundle = result.data.admin.tools.bundles[0];
+                expect(bundle.name).to.eq('ModuleProvider');
+                expect(bundle.displayName).to.eq('ModuleProvider (module-provider)');
+                expect(bundle.symbolicName).to.eq('module-provider');
+                expect(bundle.version).to.eq('1.1.0');
+            });
+        });
     });
 });

--- a/tests/cypress/fixtures/getBundles.graphql
+++ b/tests/cypress/fixtures/getBundles.graphql
@@ -4,7 +4,8 @@ query($nameRegExp: String, $areModules: Boolean, $withUnsupportedDependenciesOnl
             bundles(nameRegExp: $nameRegExp, areModules: $areModules, withUnsupportedDependenciesOnly: $withUnsupportedDependenciesOnly) {
                 displayName,
                 name,
-                symbolicName
+                symbolicName,
+                version
                 dependencies(supported: $supported, statuses: $statuses) {
                     type,
                     name,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
https://jira.jahia.org/browse/BACKLOG-23172

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Add a `version` field to the `bundle` node.
