### PR TITLE
QA-15354: Escape Groovy script displayed

### DIFF
--- a/src/main/resources/groovyConsole.jsp
+++ b/src/main/resources/groovyConsole.jsp
@@ -177,7 +177,7 @@
 
             <p>
                     <textarea rows="25" style="width: 100%" id="text" name="script"
-                              onkeyup="if ((event || window.event).keyCode == 13 && (event || window.event).ctrlKey && confirm(<%=GroovyConsoleHelper.WARN_MSG%>')) document.getElementById('groovyForm').submit();">${param.script}</textarea>
+                              onkeyup="if ((event || window.event).keyCode == 13 && (event || window.event).ctrlKey && confirm(<%=GroovyConsoleHelper.WARN_MSG%>')) document.getElementById('groovyForm').submit();">${fn:escapeXml(param.script)}</textarea>
             </p>
         </c:when>
         <c:otherwise>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
https://jira.jahia.org/browse/QA-15354
## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Escape the Groovy script being displayed on the page.
This ensures the script is exactly as it's originally entered by the user, and the content is not displayed as HTML content.

