### PR TITLE
ci: Added missing credentials to publish the release

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -71,6 +71,11 @@
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
+        <server>
+            <id>jahia-releases</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>        
     </servers>
     <pluginGroups>
         <pluginGroup>org.owasp</pluginGroup>


### PR DESCRIPTION

The credentials to the release repo was missing.

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.0:deploy (default-deploy) on project tools-test-module: Failed to deploy artifacts: Could not transfer artifact org.jahia.test:tools-test-module:pom:5.1.0 from/to jahia-releases (https://devtools.jahia.com/nexus/content/repositories/jahia-releases): status code: 401, reason phrase: Unauthorized (401) -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```