### PR TITLE
feat(definitions): improve search accuracy

### DIFF
--- a/src/javascript/datatable.js
+++ b/src/javascript/datatable.js
@@ -7,11 +7,36 @@ import 'datatables.net-bs5/css/dataTables.bootstrap5.min.css';
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-table="dataTable"]')
         .forEach(dataTable => {
-            // Instanciate a datatable (ignore sonar warings)
+            // Instantiate a datatable (ignore sonar warnings)
+            // eslint-disable-next-line no-new
+            new Datatable(dataTable); // NOSONAR
+        });
+    document.querySelectorAll('[data-table="dataTableDefinitionsBrowser"]')
+        .forEach(dataTable => {
+            // Instantiate a datatable (ignore sonar warnings)
             // eslint-disable-next-line no-new
             new Datatable(dataTable, {
                 pageLength: 300,
-                lengthMenu: [10, 25, 50, 100, 300]
+                lengthMenu: [10, 25, 50, 100, 300],
+                columns: [
+                    null,
+                    null,
+                    {
+                        // Tweak the "rendering" of the 3rd columns:
+                        // Only return the <ol> > <li> text (and exclude, for instance, the whole '<div style="display:none">' used to show details of a node type definition)
+                        render: function (data, type) {
+                            if (type === 'filter') {
+                                // Parse HTML and extract <ol> > <li> text
+                                const temp = document.createElement('div');
+                                temp.innerHTML = data;
+                                const items = temp.querySelectorAll('ol > li');
+                                return Array.from(items).map(li => li.textContent.trim()).join(' ');
+                            }
+
+                            return data;
+                        }
+                    }
+                ]
             }); // NOSONAR
         });
 });

--- a/src/main/resources/definitionsBrowser.jsp
+++ b/src/main/resources/definitionsBrowser.jsp
@@ -111,7 +111,7 @@
 <%@ include file="logout.jspf" %>
 <%@ include file="gotoIndex.jspf" %>
 <div class="container-fluid">
-    <table id="moduleTable" class="table table-striped compact" data-table="dataTable">
+    <table id="moduleTable" class="table table-striped compact" data-table="dataTableDefinitionsBrowser">
         <thead>
         <tr>
             <th>N°</th>


### PR DESCRIPTION
Part of https://github.com/Jahia/tools/issues/198.
### Description
Improve the search accuracy on the nodetype definition browser page (http://localhost:8080/modules/tools/definitionsBrowser.jsp).

### Details

A custom rendering is used on the 3rd column, to return only the content we want to search on: the inner text of the `<li>` items of the `<ol>`.
Apply this only to the definitions browser page by using a unique `data-table` identifier (_dataTableDefinitionsBrowser_). Note that this also restricts the changes in https://github.com/Jahia/tools/pull/210 to only that definitions browser page.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
