### PR TITLE
feat: Remove pagination on definitions & modules browser pages

### DIFF
--- a/src/javascript/datatable.js
+++ b/src/javascript/datatable.js
@@ -11,13 +11,18 @@ document.addEventListener('DOMContentLoaded', () => {
             // eslint-disable-next-line no-new
             new Datatable(dataTable); // NOSONAR
         });
+    document.querySelectorAll('[data-table="dataTableModulesBrowser"]')
+        .forEach(dataTable => {
+            // Instantiate a datatable (ignore sonar warnings)
+            // eslint-disable-next-line no-new
+            new Datatable(dataTable, {paging: false}); // NOSONAR
+        });
     document.querySelectorAll('[data-table="dataTableDefinitionsBrowser"]')
         .forEach(dataTable => {
             // Instantiate a datatable (ignore sonar warnings)
             // eslint-disable-next-line no-new
-            new Datatable(dataTable, {
-                pageLength: 300,
-                lengthMenu: [10, 25, 50, 100, 300],
+            new Datatable(dataTable, { // NOSONAR
+                paging: false,
                 columns: [
                     null,
                     null,
@@ -37,6 +42,6 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                     }
                 ]
-            }); // NOSONAR
+            });
         });
 });

--- a/src/main/resources/modulesBrowser.jsp
+++ b/src/main/resources/modulesBrowser.jsp
@@ -79,7 +79,7 @@
 <%@ include file="logout.jspf" %>
 <%@ include file="gotoIndex.jspf" %>
 <div class="container-fluid">
-    <table id="moduleTable" class="table table-striped compact" data-table="dataTable">
+    <table id="moduleTable" class="table table-striped compact" data-table="dataTableModulesBrowser">
         <thead>
         <tr>
             <th>N°</th>


### PR DESCRIPTION
Part of https://github.com/Jahia/tools/issues/198.
### Description
Remove the pagination on [tools/definitionsBrowser.jsp](http://localhost:8080/modules/tools/definitionsBrowser.jsp) and [tools/modulesBrowser.jsp](http://localhost:8080/modules/tools/modulesBrowser.jsp).

Rationality for the change: the pagination is performed client-side and considering the low number of items we (usually) have on those pages, it's simpler to just remove the pagination.

**NB:** the pagination is kept on the ehcache pages that also use a `Datatable`.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
