### PR TITLE
fix: Header inconsistency

### DIFF
--- a/src/main/java/org/jahia/modules/tools/JspPrecompileServlet.java
+++ b/src/main/java/org/jahia/modules/tools/JspPrecompileServlet.java
@@ -115,13 +115,13 @@ public class JspPrecompileServlet extends HttpServlet {
             out.println("    </ul>");
             out.println("    <hgroup>");
             out.println("        <h1>JSP Compilation</h1>");
+            if (!foundJsps.isEmpty()) {
+                out.print("<span>Found <strong>");
+                out.print(foundJsps.size());
+                out.println("</strong> JSPs</span>");
+            }
             out.println("    </hgroup>");
             out.println("</header>");
-            if (!foundJsps.isEmpty()) {
-                out.print("<p>Found <strong>");
-                out.print(foundJsps.size());
-                out.println("</strong> JSPs</p>");
-            }
 
             out.println("<h2>Pre-compile:</h2>");
             out.println("<ul>");

--- a/src/main/resources/commons/header.jspf
+++ b/src/main/resources/commons/header.jspf
@@ -6,10 +6,10 @@
             <a href='${pageContext.request.contextPath}/cms/logout?redirect=${pageContext.request.contextPath}/start'><span
                     class="material-symbols-outlined">logout</span>Logout</a></li>
     </ul>
-    <hrgroup>
+    <hgroup>
         <h1>${title}</h1>
         ${description}
-    </hrgroup>
+    </hgroup>
     <c:if test="${! empty headerActions}">
         <ul class="page-header_toolbar">
             ${headerActions}

--- a/src/main/resources/css/tools.css
+++ b/src/main/resources/css/tools.css
@@ -47,6 +47,11 @@ fieldset {
     border: 1px solid #cfcfcf;
 }
 
+hgroup p {
+    margin-top: 0;
+    margin-bottom: 0.3rem;
+}
+
 fieldset li {
     margin-bottom: 0.5rem;
 }

--- a/src/main/resources/definitionsBrowser.jsp
+++ b/src/main/resources/definitionsBrowser.jsp
@@ -106,7 +106,7 @@
         // todo : uregister node type from jackrabbit
     }
 %>
-<body id="dt_example">
+<body id="dt_example" class="hasDataTable">
 <%@ include file="commons/header.jspf" %>
 <div class="container-fluid">
     <div style="background: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 16px; margin-bottom: 24px; border-radius: 4px; font-weight: bold;">

--- a/src/main/resources/log4jAdmin.jsp
+++ b/src/main/resources/log4jAdmin.jsp
@@ -148,25 +148,6 @@
         body {
             position: relative;
         }
-/*
-        h1 {
-            margin-top: 20px;
-            font: 1.5em Verdana, Arial, Helvetica sans-serif;
-        }
-
-        h2 {
-            margin-top: 10px;
-            font: 0.75em Verdana, Arial, Helvetica sans-serif;
-            text-align: left;
-        }
-
-/*
-        a, a:link, a:visited, a:active {
-            color: red;
-            text-decoration: none;
-            text-transform: uppercase;
-        }
-*/
 
         table {
             width: 100%;

--- a/src/main/resources/log4jAdmin.jsp
+++ b/src/main/resources/log4jAdmin.jsp
@@ -147,12 +147,8 @@
 
         body {
             position: relative;
-            margin: 10px;
-
-            padding: 0px;
-            color: #333;
         }
-
+/*
         h1 {
             margin-top: 20px;
             font: 1.5em Verdana, Arial, Helvetica sans-serif;

--- a/src/main/resources/modulesBrowser.jsp
+++ b/src/main/resources/modulesBrowser.jsp
@@ -73,7 +73,7 @@
         });
     }
 %>
-<body id="dt_example">
+<body id="dt_example" class="hasDataTable">
 <%@ include file="commons/header.jspf" %>
 <div class="container-fluid">
     <table id="moduleTable" class="table table-striped compact" data-table="dataTableModulesBrowser">


### PR DESCRIPTION
### Description
Following feedbacks from https://github.com/Jahia/tools/pull/227#issuecomment-3057310079
- Add the CSS class `hasDataTable` to override some styles on missing pages
- Fix typo with the tag `hgroup`
- Reduce spacing when a `p` is used into the header's description

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
