### PR TITLE
fix: Header inconsistency with cache pages

### DIFF
--- a/src/main/resources/ehcache/ehcache_cj.jsp
+++ b/src/main/resources/ehcache/ehcache_cj.jsp
@@ -59,7 +59,7 @@
         pageContext.setAttribute("cache", cache);
         pageContext.setAttribute("stats", new EhCacheStatisticsWrapper(cache.getStatistics()));
     %>
-    <body id="dt_example" class="container-fluid hasDataTable">
+    <body id="dt_example" class="hasDataTable">
     <c:set var="headerActions">
         <li><a href="?refresh&toolAccessToken=${toolAccessToken}"><span class="material-symbols-outlined">Refresh</span>refresh</a></li>
         <li><a href="?flush=true&toolAccessToken=${toolAccessToken}"

--- a/src/main/resources/ehcache/ehcache_cj_dep.jsp
+++ b/src/main/resources/ehcache/ehcache_cj_dep.jsp
@@ -44,7 +44,7 @@
         pageContext.setAttribute("keys", keys);
         pageContext.setAttribute("cache", cache);
     %>
-    <body id="dt_example" class="container-fluid hasDataTable">
+    <body id="dt_example" class="hasDataTable">
     <c:set var="headerActions">
         <li><a href="?flush=true&toolAccessToken=${toolAccessToken}"
                onclick="return confirm('This will flush the content of the cache. Would you like to continue?')"

--- a/src/main/resources/ehcache/ehcache_details.jsp
+++ b/src/main/resources/ehcache/ehcache_details.jsp
@@ -48,7 +48,7 @@
     <li><a href="<c:url value="/modules/tools/cache.jsp"/>"><span class="material-symbols-outlined">arrow_back</span>Back to caches list</a></li>
     <li><a href="?refresh&name=${param.name}&cache=${param.cache}&toolAccessToken=${toolAccessToken}"><span class="material-symbols-outlined">refresh</span>Refresh</a></li>
 </c:set>
-<body id="dt_example" class="container-fluid hasDataTable">
+<body id="dt_example" class="hasDataTable">
 <%@ include file="../commons/header.jspf" %>
 
 <div id="statistics">

--- a/src/main/resources/ehcache/ehcache_stats.jsp
+++ b/src/main/resources/ehcache/ehcache_stats.jsp
@@ -40,7 +40,7 @@
     pageContext.setAttribute("stats", new EhCacheStatisticsWrapper(cache.getStatistics()));
     pageContext.setAttribute("depstats", new EhCacheStatisticsWrapper(depCache.getStatistics()));
 %>
-<body id="dt_example" class="container-fluid hasDataTable">
+<body id="dt_example" class="hasDataTable">
 
 <c:set var="headerActions">
     <li><a href="?refresh&toolAccessToken=${toolAccessToken}"><span class="material-symbols-outlined">refresh</span>Refresh</a>&nbsp;</li>


### PR DESCRIPTION
### Description
Following feedback from https://github.com/Jahia/tools/pull/227#issuecomment-3061084021

Remove `container-fluid` class from ehcache pages to prevent CSS overrides.