### PR TITLE
feat: add environment to the header of the tools

### DIFF
--- a/src/main/java/org/jahia/modules/tools/JspPrecompileServlet.java
+++ b/src/main/java/org/jahia/modules/tools/JspPrecompileServlet.java
@@ -19,6 +19,7 @@ import org.jahia.bin.listeners.JahiaContextLoaderListener;
 import org.jahia.modules.tools.csrf.ToolsAccessTokenFilter;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.osgi.FrameworkService;
+import org.jahia.settings.SettingsBean;
 import org.jahia.utils.NoOutputResponseWrapper;
 import org.osgi.framework.Bundle;
 import org.slf4j.Logger;
@@ -120,6 +121,7 @@ public class JspPrecompileServlet extends HttpServlet {
                 out.print(foundJsps.size());
                 out.println("</strong> JSPs</span>");
             }
+            out.println("<span><strong>" + SettingsBean.getInstance().getString("jahia.environment", "") + "</strong></span>");
             out.println("    </hgroup>");
             out.println("</header>");
 

--- a/src/main/resources/commons/header.jspf
+++ b/src/main/resources/commons/header.jspf
@@ -1,3 +1,5 @@
+<%@ page import="org.jahia.settings.SettingsBean" %>
+<% String jahiaEnv = SettingsBean.getInstance().getString("jahia.environment", ""); %>
 <header class="page-header">
     <ul class="page-header_bar">
         <li><a href="<c:url value='/modules/tools/index.jsp'/>"><span class="material-symbols-outlined">home</span>Home</a>
@@ -8,7 +10,7 @@
     </ul>
     <hgroup>
         <h1>${title}</h1>
-        ${description}
+        ${description} <strong><%= jahiaEnv.isBlank() ? "" : " " + jahiaEnv %></strong>
     </hgroup>
     <c:if test="${! empty headerActions}">
         <ul class="page-header_toolbar">

--- a/src/main/resources/index.jsp
+++ b/src/main/resources/index.jsp
@@ -8,10 +8,12 @@
 <%@page import="org.jahia.osgi.BundleUtils" %>
 <%@page import="java.text.SimpleDateFormat" %>
 <%@page import="java.util.Date" %>
+<%@ page import="org.jahia.settings.SettingsBean" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <% pageContext.setAttribute("currentDate", new java.util.Date()); %>
 <c:set var="title">Support Tools</c:set>
+<% String jahiaEnv = SettingsBean.getInstance().getString("jahia.environment", ""); %>
 <head>
     <%@ include file="commons/html_header.jspf" %>
 </head>
@@ -25,7 +27,7 @@
         </a>
         </div>
         <div>
-            <span><%= Jahia.getFullProductVersion() %></span>
+            <span><%= Jahia.getFullProductVersion() %><strong><%= jahiaEnv.isBlank() ? "" : (" - " + jahiaEnv) %></strong></span>
         <ul class="page-header_toolbar">
             <% if (Jahia.isEnterpriseEdition() && BundleUtils.getBundleBySymbolicName("tools-ee", null) != null) {
                 if (Boolean.getBoolean("cluster.activated")) {
@@ -67,7 +69,7 @@
             <fieldset>
                 <legend>Administration and Guidance</legend>
                 <ul>
-                    <li><a href="<c:url value='/tools/osgi/console/'/>">OSGi console</a></li>
+                    <li><a href="<c:url value='/tools/osgi/console'/>">OSGi console</a></li>
                     <li><a href="importPackageChecker.jsp">OSGi Import-Package checker</a></li>
                     <li><a href="modules.jsp">Modules list</a></li>
                     <li><a href="jobadmin.jsp">Background job administration</a></li>


### PR DESCRIPTION
### Description
Provides the environment information in the header of the tools
The env is displayed in all tools
#### index.jsp
<img width="1059" height="256" alt="Screenshot 2025-08-05 at 13 41 55" src="https://github.com/user-attachments/assets/b049d7b6-8edc-4bf7-8a11-c5ea11bbf848" />


#### precompile jsps
<img width="315" height="286" alt="Screenshot 2025-08-05 at 13 42 11" src="https://github.com/user-attachments/assets/cf859701-973a-44c4-aefa-a290c0ff8d06" />

#### Any jsp tools
<img width="381" height="240" alt="Screenshot 2025-08-05 at 13 42 03" src="https://github.com/user-attachments/assets/b334e824-0e67-47c6-9b32-3f3d8c2fda45" />

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
