### PR TITLE
fix: Add missing import of ModuleManagementException

### DIFF
--- a/src/main/resources/jcrJarsCleanup.jsp
+++ b/src/main/resources/jcrJarsCleanup.jsp
@@ -9,6 +9,7 @@
 <%@ page import="org.jahia.services.content.JCRSessionWrapper" %>
 <%@ page import="org.jahia.services.content.JCRTemplate" %>
 <%@ page import="org.jahia.services.modulemanager.persistence.BundlePersister" %>
+<%@ page import="org.jahia.services.modulemanager.ModuleManagementException" %> <!-- needed as it is a checked exception of BundlePersister#delete(...) -->
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="javax.jcr.NodeIterator" %>


### PR DESCRIPTION
### Description

Add a missing import that seems to be required since https://github.com/Jahia/jahia-private/pull/4428.
Without it, the tests are failing (see [this run](https://github.com/Jahia/tools/actions/runs/19233345746/job/54976885487)):
```
FAILURES:
 | Suite: Mocha Tests - Total tests: 1 - Failure: 1 - Executed in 11s
 |   | - Tools index page link validation
 |   |    | - FAIL: Tools index page link validation Should verify all links return 200 status code
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
