### PR TITLE
chore: use proper StringUtils package name to remove plexus dependency

### DIFF
--- a/.chachalog/PBs1nFiG.md
+++ b/.chachalog/PBs1nFiG.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+tools: patch
+---
+
+Switched to StringUtils from Apache commons lang3 to remove plexus dependency (#313)

--- a/impl/.gitignore
+++ b/impl/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -174,12 +174,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.5.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math</artifactId>
             <version>2.2</version>

--- a/impl/src/main/java/org/jahia/modules/tools/probe/impl/ProbeServiceImpl.java
+++ b/impl/src/main/java/org/jahia/modules/tools/probe/impl/ProbeServiceImpl.java
@@ -16,7 +16,7 @@
 package org.jahia.modules.tools.probe.impl;
 
 import org.apache.commons.collections.map.UnmodifiableMap;
-import org.codehaus.plexus.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jahia.bin.Jahia;
 import org.jahia.modules.tools.probe.Probe;
 import org.jahia.modules.tools.probe.ProbeService;


### PR DESCRIPTION
### Description

Remove direct dependency to plexus-utils, by switching to org.apache.commons.lang3.StringUtils, instead of using the one from plexus.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
