### PR TITLE
feat: Introduce a new tool to check permissions on a node

### DIFF
--- a/.chachalog/4jNGGEfv.md
+++ b/.chachalog/4jNGGEfv.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+tools: minor
+---
+
+Introduce a new tool to check permissions on a node (#314)

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/ContentEditorUrlBuilder.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/ContentEditorUrlBuilder.java
@@ -1,0 +1,96 @@
+package org.jahia.modules.tools.userpermissions;
+
+/**
+ * Utility class that builds jContent deep-link URLs for opening a content node directly in the
+ * Jahia content editor (jContent).
+ *
+ * <p>The generated URL format is:
+ * <pre>
+ * {serverBase}/jahia/jcontent/{siteKey}/{lang}/{treePrefix}/{relativePath}
+ *     ?params=(sub:!f)
+ *     #(contentEditor:!((formKey:modal_0,isFullscreen:!t,lang:{lang},mode:edit,uilang:{lang},uuid:{uuid})))
+ * </pre>
+ *
+ * <p>The {@code treePrefix} is derived from the first path segment after the site root:
+ * <ul>
+ *   <li>{@code files} for nodes under {@code /sites/{siteKey}/files}</li>
+ *   <li>{@code contents} for nodes under {@code /sites/{siteKey}/contents}</li>
+ *   <li>{@code pages} for all other nodes (including {@code home})</li>
+ * </ul>
+ *
+ * <p>The tree path used in the URL points to the <em>parent</em> of the target node so that the
+ * jContent tree is positioned correctly while the editor modal opens on the node itself via its
+ * UUID.
+ */
+public final class ContentEditorUrlBuilder {
+
+    private ContentEditorUrlBuilder() {
+        // static utility class — no instances
+    }
+
+    /**
+     * Builds a jContent editor deep-link URL for the given content node.
+     *
+     * @param serverBase scheme + host + optional port, e.g. {@code http://localhost:8080}
+     * @param siteKey    Jahia site key, e.g. {@code digitall}
+     * @param lang       two-letter language code, e.g. {@code en}
+     * @param nodePath   absolute JCR path of the node to open, e.g.
+     *                   {@code /sites/digitall/home/about}
+     * @param uuid       UUID of the node (used to open the editor modal)
+     * @return fully formed jContent URL, or {@code null} if any required parameter is blank or
+     *         the node path does not belong to the given site
+     */
+    public static String build(String serverBase, String siteKey, String lang, String nodePath, String uuid) {
+        if (isBlank(serverBase) || isBlank(siteKey) || isBlank(lang) || isBlank(nodePath) || isBlank(uuid)) {
+            return null;
+        }
+
+        String sitePrefix = "/sites/" + siteKey;
+        if (!nodePath.startsWith(sitePrefix)) {
+            return null;
+        }
+
+        // Use the parent of the node as the tree context path so jContent highlights the correct
+        // folder in the navigation tree while the editor modal opens on the node itself.
+        String treeNodePath = nodePath;
+        int lastSlash = nodePath.lastIndexOf('/');
+        if (lastSlash > sitePrefix.length()) {
+            treeNodePath = nodePath.substring(0, lastSlash);
+        }
+
+        // Build the relative path (after stripping the site prefix).
+        String relativePath;
+        if (treeNodePath.equals(sitePrefix)) {
+            relativePath = "home";
+        } else if (treeNodePath.startsWith(sitePrefix + "/")) {
+            relativePath = treeNodePath.substring((sitePrefix + "/").length());
+        } else {
+            return null;
+        }
+
+        if (isBlank(relativePath)) {
+            return null;
+        }
+
+        // Determine the jContent tree prefix from the first path segment.
+        String[] segments = relativePath.split("/", 2);
+        String firstSegment = segments[0];
+        String prefix;
+        if ("files".equals(firstSegment)) {
+            prefix = "files";
+        } else if ("contents".equals(firstSegment)) {
+            prefix = "contents";
+        } else {
+            prefix = "pages";
+        }
+
+        String treePath = prefix + "/" + relativePath;
+        return serverBase + "/jahia/jcontent/" + siteKey + "/" + lang + "/" + treePath
+                + "?params=(sub:!f)#(contentEditor:!((formKey:modal_0,isFullscreen:!t,lang:" + lang
+                + ",mode:edit,uilang:" + lang + ",uuid:" + uuid + ")))";
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/PermCheckMatch.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/PermCheckMatch.java
@@ -1,0 +1,102 @@
+package org.jahia.modules.tools.userpermissions;
+
+/**
+ * Immutable record of one role that was found to provide a specific queried permission to the
+ * inspected user, produced by the quick <em>permission check</em> feature of
+ * {@link UserPermissionsAnalyzer}.
+ *
+ * <p>When the user submits a permission name to check (e.g. {@code jcr:read}), the analyzer
+ * calls {@code JCRNodeWrapper.hasPermission()} to obtain the authoritative yes/no answer and
+ * then scans the resolved {@link RoleResult} list to identify which role(s) actually provide
+ * that permission — producing one {@code PermCheckMatch} per matching role.
+ */
+public class PermCheckMatch {
+
+    /** Name of the role that provides the queried permission. */
+    private final String roleName;
+
+    /** Absolute JCR path of the content node on whose {@code j:acl} the granting ACE was found. */
+    private final String grantPath;
+
+    /** ACE type: {@code "GRANT"} or {@code "DENY"}. */
+    private final String grantType;
+
+    /**
+     * Scope at which the permission was found: {@code "node"} for a node-level permission or
+     * {@code "site"} for a permission from a {@code jnt:externalPermissions} group.
+     */
+    private final String level;
+
+    /**
+     * Human-readable explanation of why this match was found, e.g.
+     * {@code "via aggregate privilege: jcr:write"} or the external-permissions group name.
+     * May be an empty string when the permission name matched directly.
+     */
+    private final String detail;
+
+    /**
+     * Pre-computed jContent deep-link URL for opening the granting content node in the editor,
+     * or {@code null} if the URL could not be built.
+     */
+    private final String contentEditorUrl;
+
+    /**
+     * Constructs a permission-check match record.
+     *
+     * @param roleName         name of the matching role
+     * @param grantPath        path of the content node carrying the granting ACE
+     * @param grantType        {@code "GRANT"} or {@code "DENY"}
+     * @param level            {@code "node"} or {@code "site"}
+     * @param detail           explanation string (may be empty, never {@code null})
+     * @param contentEditorUrl pre-computed editor URL, or {@code null}
+     */
+    public PermCheckMatch(String roleName, String grantPath, String grantType, String level, String detail,
+            String contentEditorUrl) {
+        this.roleName = roleName;
+        this.grantPath = grantPath;
+        this.grantType = grantType;
+        this.level = level;
+        this.detail = detail;
+        this.contentEditorUrl = contentEditorUrl;
+    }
+
+    /** @return name of the role that provides the queried permission */
+    public String getRoleName() {
+        return roleName;
+    }
+
+    /** @return path of the content node carrying the granting ACE */
+    public String getGrantPath() {
+        return grantPath;
+    }
+
+    /** @return {@code "GRANT"} or {@code "DENY"} */
+    public String getGrantType() {
+        return grantType;
+    }
+
+    /** @return {@code "node"} for a node-level permission, {@code "site"} for a site-level one */
+    public String getLevel() {
+        return level;
+    }
+
+    /**
+     * Returns an explanation of the match, e.g. {@code "via aggregate privilege: jcr:write"}.
+     * Empty when the permission name matched directly.
+     *
+     * @return detail string, never {@code null}
+     */
+    public String getDetail() {
+        return detail;
+    }
+
+    /**
+     * Returns the pre-computed jContent deep-link URL for the granting content node, or
+     * {@code null} if it could not be constructed.
+     *
+     * @return content editor URL, or {@code null}
+     */
+    public String getContentEditorUrl() {
+        return contentEditorUrl;
+    }
+}

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/PermissionEntry.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/PermissionEntry.java
@@ -1,0 +1,80 @@
+package org.jahia.modules.tools.userpermissions;
+
+/**
+ * Immutable value object representing a single resolved permission entry in the permission tree.
+ *
+ * <p>Permissions are stored as paths relative to the {@code /permissions} JCR node, for example
+ * {@code /jContentActions/pageTreeActions/deletePageAction}. Simple permissions that could not be
+ * resolved in the tree are stored as their raw name (e.g. {@code api-access}).
+ *
+ * <p>The helper methods {@link #getLocalName()}, {@link #getDepth()}, and {@link #getIndentPx()}
+ * are designed for direct use in JSP/JSTL view templates.
+ */
+public class PermissionEntry {
+
+    /** Path relative to {@code /permissions}, e.g. {@code /jContentActions/pageTreeActions/deletePageAction}. */
+    private final String path;
+
+    /**
+     * Creates a new entry for the given permission path.
+     *
+     * @param path path relative to {@code /permissions}, or a raw permission name if the node could
+     *             not be found in the permission tree
+     */
+    public PermissionEntry(String path) {
+        this.path = path;
+    }
+
+    /**
+     * Returns the full permission path as stored in this entry.
+     *
+     * @return permission path, never {@code null}
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Returns {@code true} when the path contains at least one {@code /}, indicating that the
+     * permission was resolved in the {@code /permissions} tree and has a known ancestry.
+     *
+     * @return {@code true} for tree-resolved permissions, {@code false} for raw names
+     */
+    public boolean isHierarchical() {
+        return path != null && path.contains("/");
+    }
+
+    /**
+     * Returns the last segment of the path (the permission's own name), suitable for compact
+     * display in a UI.  For non-hierarchical entries the full path is returned unchanged.
+     *
+     * @return local permission name, e.g. {@code deletePageAction}
+     */
+    public String getLocalName() {
+        return isHierarchical() ? path.substring(path.lastIndexOf('/') + 1) : path;
+    }
+
+    /**
+     * Returns the nesting depth of this permission within the tree, computed as the number of
+     * {@code /} separators minus one.  Depth 0 means the permission sits directly under
+     * {@code /permissions} (or is a raw non-hierarchical name).
+     *
+     * @return nesting depth, always &ge; 0
+     */
+    public int getDepth() {
+        if (!isHierarchical()) {
+            return 0;
+        }
+        return Math.max(0, path.length() - path.replace("/", "").length() - 1);
+    }
+
+    /**
+     * Returns the CSS left-indent in pixels to apply when rendering nested permissions in a list,
+     * calculated as {@code depth * 14}.
+     *
+     * @return indent in pixels, always &ge; 0
+     */
+    public int getIndentPx() {
+        return getDepth() * 14;
+    }
+}

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/PermissionExpander.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/PermissionExpander.java
@@ -1,0 +1,123 @@
+package org.jahia.modules.tools.userpermissions;
+
+import org.jahia.services.content.JCRContentUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+
+/**
+ * Utility class that resolves a Jahia permission name to its full set of
+ * {@link PermissionEntry} objects by walking the {@code /permissions} JCR tree.
+ *
+ * <p>Jahia organises permissions hierarchically under {@code /permissions}.  When a role grants
+ * a parent permission (e.g. {@code jContentActions}), all of its {@code jnt:permission}
+ * descendants are implicitly granted as well.  This class expands a single permission name into
+ * the complete set of paths so the UI can display the full hierarchy.
+ *
+ * <p>Usage:
+ * <pre>
+ *     List&lt;PermissionEntry&gt; entries = PermissionExpander.expand("jContentActions", editSession);
+ *     // entries contains /jContentActions, /jContentActions/pageTreeActions, ...
+ * </pre>
+ */
+public final class PermissionExpander {
+
+    private static final Logger logger = LoggerFactory.getLogger(PermissionExpander.class);
+
+    private PermissionExpander() {
+        // static utility class — no instances
+    }
+
+    /**
+     * Resolves {@code permName} to its entry in the {@code /permissions} tree and returns a list
+     * containing the permission's own path followed by all descendant {@code jnt:permission}
+     * paths (depth-first order).
+     *
+     * <p>Lookup strategy:
+     * <ol>
+     *   <li>Strip any JCR namespace prefix (e.g. {@code jcr:read_default} → {@code read_default})
+     *       since workspace-scoped names may include a prefix not present in node names.</li>
+     *   <li>Query {@code /permissions} using {@code localname() = localName} to find the node.</li>
+     *   <li>Recurse into all {@code jnt:permission} children via {@link #collect}.</li>
+     *   <li>If the node is not found in the tree, fall back to returning the raw {@code permName}
+     *       as a single non-hierarchical entry.</li>
+     * </ol>
+     *
+     * @param permName the permission name to expand, e.g. {@code jContentActions} or
+     *                 {@code jcr:read_default}; {@code null} or blank values are silently ignored
+     * @param session  a JCR session with read access to {@code /permissions} (typically the
+     *                 system session in the {@code default} workspace)
+     * @return non-null list of resolved entries; contains at least one element unless
+     *         {@code permName} is blank
+     */
+    public static List<PermissionEntry> expand(String permName, Session session) {
+        List<PermissionEntry> permissions = new ArrayList<PermissionEntry>();
+        if (permName == null || permName.trim().isEmpty() || session == null) {
+            return permissions;
+        }
+
+        // Strip namespace prefix so workspace-scoped names like "jcr:read_default" resolve correctly.
+        String localName = permName.contains(":") ? permName.substring(permName.indexOf(':') + 1) : permName;
+        try {
+            NodeIterator nodes = session.getWorkspace().getQueryManager().createQuery(
+                    "SELECT * FROM [jnt:permission] WHERE localname()='" + JCRContentUtils.sqlEncode(localName)
+                            + "' AND ISDESCENDANTNODE('/permissions')",
+                    Query.JCR_SQL2).execute().getNodes();
+            if (nodes.hasNext()) {
+                Node permissionNode = nodes.nextNode();
+                // Build the path relative to /permissions (strip the root prefix).
+                String relativePath = permissionNode.getPath().startsWith("/permissions")
+                        ? permissionNode.getPath().substring("/permissions".length())
+                        : permissionNode.getPath();
+                collect(permissionNode, relativePath, permissions);
+                return permissions;
+            }
+        } catch (RepositoryException e) {
+            logger.debug("Unable to expand permission {}", permName, e);
+        }
+
+        // Fallback: permission node not found — return the raw name as-is.
+        addIfMissing(permissions, permName);
+        return permissions;
+    }
+
+    /**
+     * Recursively adds the given node's path and all of its {@code jnt:permission} descendant
+     * paths to {@code target} in depth-first order.
+     *
+     * @param node    current permission node
+     * @param relPath path of {@code node} relative to {@code /permissions}
+     * @param target  accumulator for the collected entries
+     */
+    private static void collect(Node node, String relPath, List<PermissionEntry> target) {
+        try {
+            addIfMissing(target, relPath);
+            NodeIterator children = node.getNodes();
+            while (children.hasNext()) {
+                Node child = children.nextNode();
+                if (child.isNodeType("jnt:permission")) {
+                    collect(child, relPath + "/" + child.getName(), target);
+                }
+            }
+        } catch (RepositoryException e) {
+            logger.debug("Unable to collect permission descendants for {}", relPath, e);
+        }
+    }
+
+    /** Adds a new {@link PermissionEntry} for {@code path} only if no entry with that path exists yet. */
+    private static void addIfMissing(List<PermissionEntry> target, String path) {
+        for (PermissionEntry entry : target) {
+            if (entry.getPath().equals(path)) {
+                return;
+            }
+        }
+        target.add(new PermissionEntry(path));
+    }
+}

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/RoleResult.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/RoleResult.java
@@ -1,0 +1,154 @@
+package org.jahia.modules.tools.userpermissions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable snapshot of one effective role assignment for the inspected user on the target node.
+ *
+ * <p>Each instance corresponds to a single entry in the resolved ACL chain: the role
+ * ({@link #getRoleName()}), how it was granted ({@link #getGrantType()}), which principal matched
+ * ({@link #getMatchedPrincipal()}), and on which content node the grant was recorded
+ * ({@link #getContentGrantPath()}).
+ *
+ * <p>The role's permissions are split into two categories:
+ * <ul>
+ *   <li><strong>Node permissions</strong> — permissions evaluated against the content node itself,
+ *       collected from the {@code j:permissionNames} / {@code j:permissions} properties of the
+ *       role's {@code jnt:role} node (and its parent roles).</li>
+ *   <li><strong>Site permissions</strong> — permissions evaluated against the site node, one
+ *       {@link SitePermGroup} per {@code jnt:externalPermissions} child of the role node.</li>
+ * </ul>
+ *
+ * <p>The {@link #getContentEditorUrl()} field is pre-computed by {@link ContentEditorUrlBuilder}
+ * and ready to embed directly in HTML as a deep-link into jContent's content editor.
+ */
+public class RoleResult {
+
+    /** Local name of the role as it appears under {@code /roles}, e.g. {@code translator-en}. */
+    private final String roleName;
+
+    /**
+     * ACE type: {@code "GRANT"} or {@code "DENY"}.
+     * External ACEs are always surfaced as {@code "GRANT"} after source resolution.
+     */
+    private final String grantType;
+
+    /**
+     * The principal string that matched the inspected user, e.g. {@code u:mathias} for a direct
+     * user grant or {@code g:sample-group} for a group-based grant.
+     */
+    private final String matchedPrincipal;
+
+    /**
+     * Absolute JCR path of the content node on whose {@code j:acl} the granting ACE lives.
+     * For roles surfaced via a site-level {@code jnt:externalAce}, this is the path of the
+     * original content node resolved through the {@code j:sourceAce} reference chain.
+     */
+    private final String contentGrantPath;
+
+    /**
+     * Absolute JCR path of the role definition node under {@code /roles}, or {@code null} if the
+     * role could not be resolved in the repository.
+     */
+    private final String roleNodePath;
+
+    /** Permissions evaluated against the content node (from the role's {@code j:permissionNames}). */
+    private final List<PermissionEntry> nodePermissions;
+
+    /** Site-level permission groups (one per {@code jnt:externalPermissions} child of the role). */
+    private final List<SitePermGroup> sitePermissions;
+
+    /**
+     * Pre-computed jContent deep-link URL for opening the granting content node in the editor,
+     * or {@code null} if the URL could not be built (e.g. node outside a site tree).
+     */
+    private final String contentEditorUrl;
+
+    /**
+     * Constructs a fully populated, immutable role result.
+     *
+     * @param roleName          local role name
+     * @param grantType         {@code "GRANT"} or {@code "DENY"}
+     * @param matchedPrincipal  principal that matched the inspected user (prefixed with {@code u:} or {@code g:})
+     * @param contentGrantPath  path of the content node carrying the granting ACE
+     * @param roleNodePath      path of the role definition node, or {@code null}
+     * @param nodePermissions   permissions evaluated at node level
+     * @param sitePermissions   permissions evaluated at site level, grouped by external-permissions name
+     * @param contentEditorUrl  pre-computed jContent editor URL, or {@code null}
+     */
+    public RoleResult(String roleName, String grantType, String matchedPrincipal, String contentGrantPath,
+            String roleNodePath, List<PermissionEntry> nodePermissions, List<SitePermGroup> sitePermissions,
+            String contentEditorUrl) {
+        this.roleName = roleName;
+        this.grantType = grantType;
+        this.matchedPrincipal = matchedPrincipal;
+        this.contentGrantPath = contentGrantPath;
+        this.roleNodePath = roleNodePath;
+        this.nodePermissions = Collections.unmodifiableList(new ArrayList<PermissionEntry>(nodePermissions));
+        this.sitePermissions = Collections.unmodifiableList(new ArrayList<SitePermGroup>(sitePermissions));
+        this.contentEditorUrl = contentEditorUrl;
+    }
+
+    /** @return local role name, e.g. {@code translator-en} */
+    public String getRoleName() {
+        return roleName;
+    }
+
+    /** @return {@code "GRANT"} or {@code "DENY"} */
+    public String getGrantType() {
+        return grantType;
+    }
+
+    /**
+     * Returns the principal that matched the inspected user, prefixed with {@code u:} for user
+     * principals or {@code g:} for group principals.
+     *
+     * @return matched principal string
+     */
+    public String getMatchedPrincipal() {
+        return matchedPrincipal;
+    }
+
+    /**
+     * Returns the absolute path of the content node on whose {@code j:acl} the granting ACE was
+     * found.  For roles surfaced via a site-level external ACE this is the source content node
+     * resolved through {@code j:sourceAce}, not the site node itself.
+     *
+     * @return content node path
+     */
+    public String getContentGrantPath() {
+        return contentGrantPath;
+    }
+
+    /**
+     * Returns the absolute path of the role's definition node under {@code /roles}, or
+     * {@code null} when the role could not be located.
+     *
+     * @return role node path, or {@code null}
+     */
+    public String getRoleNodePath() {
+        return roleNodePath;
+    }
+
+    /** @return immutable list of node-level permissions */
+    public List<PermissionEntry> getNodePermissions() {
+        return nodePermissions;
+    }
+
+    /** @return immutable list of site-level permission groups */
+    public List<SitePermGroup> getSitePermissions() {
+        return sitePermissions;
+    }
+
+    /**
+     * Returns the pre-computed jContent deep-link URL for editing the granting content node,
+     * or {@code null} if it could not be constructed.
+     *
+     * @return content editor URL, or {@code null}
+     */
+    public String getContentEditorUrl() {
+        return contentEditorUrl;
+    }
+}

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/SitePermGroup.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/SitePermGroup.java
@@ -1,0 +1,75 @@
+package org.jahia.modules.tools.userpermissions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable snapshot of the site-level permissions that a role grants via one of its
+ * {@code jnt:externalPermissions} child nodes.
+ *
+ * <p>In Jahia, a role can carry <em>external permissions</em>: when the role is granted on a
+ * content node, Jahia's {@code AclListener} automatically creates a mirror ACE on the site node
+ * so that the listed permissions are checked against the site context rather than the content
+ * node itself.  Each {@code jnt:externalPermissions} child gives a distinct group of such
+ * permissions; this class models one such group.
+ *
+ * <p>Example: the {@code translator-en} role has a {@code currentSite-access} external-permissions
+ * child with {@code j:path=currentSite} — granting it implicitly grants {@code jContentAccess}
+ * (and siblings) on the site.
+ */
+public class SitePermGroup {
+
+    /** Name of the {@code jnt:externalPermissions} child node, e.g. {@code currentSite-access}. */
+    private final String name;
+
+    /**
+     * Value of the {@code j:path} property on the {@code jnt:externalPermissions} node,
+     * indicating where the permissions are evaluated (e.g. {@code currentSite}).
+     */
+    private final String targetPath;
+
+    /** Resolved permissions provided by this external-permissions group. */
+    private final List<PermissionEntry> permissions;
+
+    /**
+     * Creates a new site permission group.
+     *
+     * @param name        name of the {@code jnt:externalPermissions} child node
+     * @param targetPath  value of {@code j:path} — where the permissions are checked
+     * @param permissions resolved permissions belonging to this group
+     */
+    public SitePermGroup(String name, String targetPath, List<PermissionEntry> permissions) {
+        this.name = name;
+        this.targetPath = targetPath;
+        this.permissions = Collections.unmodifiableList(new ArrayList<PermissionEntry>(permissions));
+    }
+
+    /**
+     * Returns the name of the {@code jnt:externalPermissions} child node.
+     *
+     * @return group name, e.g. {@code currentSite-access}
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the path expression indicating where these permissions are evaluated,
+     * as declared in the {@code j:path} property of the {@code jnt:externalPermissions} node.
+     *
+     * @return target path expression, e.g. {@code currentSite}
+     */
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    /**
+     * Returns the immutable list of resolved permissions belonging to this group.
+     *
+     * @return permission entries, never {@code null}
+     */
+    public List<PermissionEntry> getPermissions() {
+        return permissions;
+    }
+}

--- a/impl/src/main/java/org/jahia/modules/tools/userpermissions/UserPermissionsAnalyzer.java
+++ b/impl/src/main/java/org/jahia/modules/tools/userpermissions/UserPermissionsAnalyzer.java
@@ -1,0 +1,987 @@
+package org.jahia.modules.tools.userpermissions;
+
+import org.apache.jackrabbit.core.security.JahiaPrivilegeRegistry;
+import org.jahia.registries.ServicesRegistry;
+import org.jahia.services.content.JCRContentUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.decorator.JCRUserNode;
+import org.jahia.services.usermanager.JahiaGroupManagerService;
+import org.jahia.services.usermanager.JahiaUser;
+import org.jahia.services.usermanager.JahiaUserManagerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.query.Query;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.Privilege;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Main analysis engine for the User Permissions Inspector tool.
+ *
+ * <p>Given a Jahia username, a JCR node path, and a workspace name, this class resolves every
+ * effective role that applies to the user on the target node and returns them as a list of
+ * {@link RoleResult} objects ready for display in the JSP view.
+ *
+ * <h3>ACL resolution algorithm</h3>
+ * <p>Jahia's {@code JCRNodeWrapper.getAclEntries()} returns a flat map of
+ * {@code principal → List<String[]>} where each {@code String[]} is
+ * {@code [grantedOnPath, grantType, roleName]}.  Three ACE types are possible:
+ * <ul>
+ *   <li><b>GRANT / DENY</b> — standard ACE from a {@code jnt:ace} node on a content node.</li>
+ *   <li><b>EXTERNAL</b> — mirror ACE created on the site node by Jahia's {@code AclListener}
+ *       when a role that has {@code jnt:externalPermissions} children is granted on a content
+ *       node.  The role name in this case has the form {@code baseRole/extPermName}, e.g.
+ *       {@code translator-en/currentSite-access}.</li>
+ * </ul>
+ *
+ * <p>Analysis is done in two passes:
+ * <ol>
+ *   <li><b>Pass 1 — GRANT / DENY</b>: Collect direct role grants for the user (and their
+ *       groups).  For each role only the deepest (most specific) grant path is kept.</li>
+ *   <li><b>Pass 2 — EXTERNAL</b>: For each orphan EXTERNAL entry (role not yet in the result
+ *       map from Pass 1), navigate the {@code jnt:externalAce} node on the site's {@code j:acl}
+ *       and iterate the multi-valued {@code j:sourceAce} REFERENCE property to recover the
+ *       original content node(s) where the role was actually granted.  Each distinct source
+ *       node produces a separate result entry, disambiguated with a {@code §N} suffix on the
+ *       map key.</li>
+ * </ol>
+ *
+ * <h3>Permission check</h3>
+ * <p>When {@code checkPermission} is supplied, the analyzer opens a user session (temporarily
+ * switching {@code JCRSessionFactory}'s current user to the target user) and calls
+ * {@code JCRNodeWrapper.hasPermission()} for an authoritative answer.  It then scans the
+ * resolved role list to identify which role and which permission entry provides the queried
+ * permission, using both exact name matching and aggregate-privilege expansion.
+ */
+public class UserPermissionsAnalyzer {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserPermissionsAnalyzer.class);
+
+    /**
+     * Separator used to make map keys unique when the same role is granted via multiple content
+     * nodes (e.g. through a group that has the role on several pages).
+     * Value: {@code §} (U+00A7 SECTION SIGN).
+     */
+    private static final String ROLE_DUPLICATE_SEPARATOR = "\u00a7";
+
+    /** Workspace name used to resolve role definition nodes under {@code /roles}. */
+    private static final String EDIT_WORKSPACE = "default";
+
+    /** JCR node type name for Jahia role nodes. */
+    private static final String ROLE_NODE_TYPE = "jnt:role";
+
+    /**
+     * Immutable container for all data produced by one {@link UserPermissionsAnalyzer#analyze} call.
+     * Instances are created by the analyzer and consumed directly by the JSP view.
+     */
+    public static class Result {
+
+        /** All effective roles resolved for the user on the target node. */
+        private final List<RoleResult> roleResults;
+
+        /**
+         * Result of {@code JCRNodeWrapper.hasPermission()} for the queried permission, or
+         * {@code null} when no permission was queried.
+         */
+        private final Boolean permGranted;
+
+        /**
+         * Error message when the {@code hasPermission()} call could not be completed (e.g. user
+         * not found), or {@code null} on success.
+         */
+        private final String permCheckError;
+
+        /**
+         * Roles identified as providing the queried permission, populated when
+         * {@code checkPermission} is supplied and at least one match is found.
+         */
+        private final List<PermCheckMatch> permCheckMatches;
+
+        /**
+         * Full permission paths that matched the queried permission, used to highlight entries
+         * in the permission lists.
+         */
+        private final Set<String> highlightedPerms;
+
+        /**
+         * Map view of {@link #highlightedPerms} keyed by path for efficient EL-based lookup in
+         * JSTL (e.g. {@code ${result.highlightedPermMap[perm.path]}}).
+         */
+        private final Map<String, Boolean> highlightedPermMap;
+
+        public Result(List<RoleResult> roleResults, Boolean permGranted, String permCheckError,
+                List<PermCheckMatch> permCheckMatches, Set<String> highlightedPerms) {
+            this.roleResults = Collections.unmodifiableList(new ArrayList<>(roleResults));
+            this.permGranted = permGranted;
+            this.permCheckError = permCheckError;
+            this.permCheckMatches = Collections.unmodifiableList(new ArrayList<>(permCheckMatches));
+            this.highlightedPerms = Collections.unmodifiableSet(new LinkedHashSet<>(highlightedPerms));
+            // Build the map eagerly so JSTL can do O(1) lookups via ${result.highlightedPermMap[perm.path]}.
+            Map<String, Boolean> highlightMap = new LinkedHashMap<>();
+            for (String highlightedPerm : this.highlightedPerms) {
+                highlightMap.put(highlightedPerm, Boolean.TRUE);
+            }
+            this.highlightedPermMap = Collections.unmodifiableMap(highlightMap);
+        }
+
+        /** @return immutable list of all effective roles for the inspected user */
+        public List<RoleResult> getRoleResults() {
+            return roleResults;
+        }
+
+        /**
+         * Returns the result of {@code JCRNodeWrapper.hasPermission()} for the queried permission,
+         * or {@code null} when no permission was queried.
+         *
+         * @return {@code Boolean.TRUE} if granted, {@code Boolean.FALSE} if denied, {@code null} if not checked
+         */
+        public Boolean getPermGranted() {
+            return permGranted;
+        }
+
+        /**
+         * Returns an error message when the permission check could not be performed (e.g. user
+         * not found), or {@code null} when the check succeeded or was not requested.
+         *
+         * @return error message, or {@code null}
+         */
+        public String getPermCheckError() {
+            return permCheckError;
+        }
+
+        /** @return immutable list of roles that provide the queried permission */
+        public List<PermCheckMatch> getPermCheckMatches() {
+            return permCheckMatches;
+        }
+
+        /**
+         * Returns a {@code Map<String, Boolean>} view of the highlighted permission set suitable
+         * for O(1) EL lookups in JSTL: {@code ${result.highlightedPermMap[perm.path]}}.
+         *
+         * @return immutable map; a {@code true} value means the path is highlighted
+         */
+        public Map<String, Boolean> getHighlightedPermMap() {
+            return highlightedPermMap;
+        }
+    }
+
+    /**
+     * Performs a complete ACL analysis for the given user on the given node.
+     *
+     * <p>Opens two JCR sessions internally:
+     * <ul>
+     *   <li>A <em>system session</em> in the requested workspace to read ACL entries and resolve
+     *       {@code jnt:externalAce} nodes.</li>
+     *   <li>A <em>system session in the {@code default} workspace</em> to resolve role definition
+     *       nodes under {@code /roles} and read their permission declarations.</li>
+     * </ul>
+     * Both sessions are closed in a {@code finally} block.
+     *
+     * @param username        Jahia username or group principal (prefix {@code g:}) to inspect
+     * @param nodePath        absolute JCR path of the node to analyse
+     * @param workspace       workspace to use: {@code "default"} or {@code "live"}
+     * @param checkPermission permission name to quick-check via {@code hasPermission()} (may be
+     *                        {@code null} or empty to skip; skipped automatically for group principals)
+     * @param userSiteKey     site key used for user and group membership resolution; may be
+     *                        {@code null} or empty to resolve against the global (non-site) context
+     * @param request         current HTTP request, used to build the server base URL for editor
+     *                        deep-links; may be {@code null} (editor links will be omitted)
+     * @return analysis result containing all resolved roles and optional permission-check data
+     * @throws javax.jcr.PathNotFoundException if {@code nodePath} does not exist in the workspace
+     * @throws RepositoryException             on any other JCR error
+     */
+    public Result analyze(String username, String nodePath, String workspace, String checkPermission,
+            String userSiteKey, HttpServletRequest request) throws RepositoryException {
+        List<RoleResult> roleResults = new ArrayList<>();
+        Boolean permGranted = null;
+        String permCheckError = null;
+        List<PermCheckMatch> permCheckMatches = new ArrayList<>();
+        Set<String> highlightedPerms = new LinkedHashSet<>();
+        // nodeSiteKey is used only for content-editor URL building (derived from the node path).
+        // userSiteKey is the explicitly chosen site for user/group membership resolution.
+        String nodeSiteKey = extractSiteKey(nodePath);
+        String resolvedUserSiteKey = (userSiteKey != null && !userSiteKey.trim().isEmpty()) ? userSiteKey : nodeSiteKey;
+        boolean isGroupPrincipal = username != null && username.startsWith("g:");
+        String serverBase = buildServerBase(request);
+        String language = "en";
+
+        JCRSessionWrapper systemSession = null;
+        JCRSessionWrapper editSession = null;
+        try {
+            systemSession = JCRSessionFactory.getInstance().getCurrentSystemSession(workspace, null, null);
+            editSession = JCRSessionFactory.getInstance().getCurrentSystemSession(EDIT_WORKSPACE, null, null);
+
+            JCRNodeWrapper node = systemSession.getNode(nodePath);
+            JahiaGroupManagerService groupMgr = ServicesRegistry.getInstance().getJahiaGroupManagerService();
+            Map<String, List<String[]>> aclEntries = node.getAclEntries();
+            Map<String, String[]> effectiveRoles = new LinkedHashMap<>();
+            List<String[]> orphanExternals = new ArrayList<>();
+
+            for (Map.Entry<String, List<String[]>> aclEntry : aclEntries.entrySet()) {
+                String principal = aclEntry.getKey();
+                if (!matchesPrincipal(username, resolvedUserSiteKey, principal, groupMgr)) {
+                    continue;
+                }
+
+                for (String[] ace : aclEntry.getValue()) {
+                    String grantedOnPath = ace[0];
+                    String grantType = ace[1];
+                    String roleName = ace[2];
+                    if ("EXTERNAL".equals(grantType)) {
+                        orphanExternals.add(new String[] {principal, grantedOnPath, roleName});
+                        continue;
+                    }
+
+                    // Find an existing entry for the same (role, principal) pair so that a
+                    // deeper path replaces a shallower one for the same principal, while a
+                    // different principal always gets its own separate card.
+                    String existingKey = findKeyForRoleAndPrincipal(effectiveRoles, roleName, principal);
+                    if (existingKey == null) {
+                        effectiveRoles.put(findUniqueKey(effectiveRoles, roleName),
+                                new String[] {grantedOnPath, grantType, principal});
+                    } else if (grantedOnPath.length() > effectiveRoles.get(existingKey)[0].length()) {
+                        effectiveRoles.put(existingKey, new String[] {grantedOnPath, grantType, principal});
+                    }
+                }
+            }
+
+            for (String[] orphanExternal : orphanExternals) {
+                String extPrincipal = orphanExternal[0];
+                String extGrantPath = orphanExternal[1];
+                String extRoleName = orphanExternal[2];
+                String extBase = extRoleName.contains("/")
+                        ? extRoleName.substring(0, extRoleName.indexOf('/')) : extRoleName;
+
+                // Always resolve j:sourceAce — even when a direct GRANT was already found in Pass 1,
+                // there may be additional content nodes (group granted same role on multiple nodes).
+                List<String> contentPaths = resolveExternalContentPaths(systemSession, extPrincipal,
+                        extGrantPath, extBase);
+
+                if (contentPaths.isEmpty() && !isAlreadyCovered(effectiveRoles, extBase)) {
+                    // Fallback only when the role is truly absent: use the site/ancestor path.
+                    contentPaths.add(extGrantPath);
+                }
+
+                for (String contentPath : contentPaths) {
+                    if (!isPathCoveredForRole(effectiveRoles, extBase, contentPath)) {
+                        effectiveRoles.put(findUniqueKey(effectiveRoles, extBase),
+                                new String[] {contentPath, "GRANT", extPrincipal});
+                    }
+                }
+            }
+
+            for (Map.Entry<String, String[]> roleEntry : effectiveRoles.entrySet()) {
+                String roleName = stripDuplicateSuffix(roleEntry.getKey());
+                String[] roleGrant = roleEntry.getValue();
+                String grantedOnPath = roleGrant[0];
+                String grantType = roleGrant[1];
+                String matchedPrincipal = roleGrant[2];
+                Node roleNode = resolveRoleNode(editSession, roleName);
+                String roleNodePath = roleNode != null ? roleNode.getPath() : null;
+                List<PermissionEntry> nodePerms = new ArrayList<>();
+                List<SitePermGroup> sitePerms = new ArrayList<>();
+                if (roleNode != null) {
+                    collectRolePermissions(roleNode, editSession, nodePerms, sitePerms);
+                }
+
+                String grantNodeUuid = null;
+                try {
+                    if (systemSession.nodeExists(grantedOnPath)) {
+                        grantNodeUuid = systemSession.getNode(grantedOnPath).getIdentifier();
+                    }
+                } catch (RepositoryException e) {
+                    logger.debug("Unable to resolve grant node UUID for {}", grantedOnPath, e);
+                }
+
+                roleResults.add(new RoleResult(roleName, grantType, matchedPrincipal, grantedOnPath, roleNodePath,
+                        nodePerms, sitePerms,
+                        ContentEditorUrlBuilder.build(serverBase, nodeSiteKey, language, grantedOnPath, grantNodeUuid)));
+            }
+
+            if (checkPermission != null && !checkPermission.trim().isEmpty()) {
+                if (isGroupPrincipal) {
+                    // hasPermission() requires a user session; it cannot be used for group principals.
+                    permCheckError = "Permission check via hasPermission() is not available for group principals.";
+                } else {
+                    permGranted = Boolean.FALSE;
+                    JahiaUser previousUser = JCRSessionFactory.getInstance().getCurrentUser();
+                    JCRSessionWrapper userSession = null;
+                    try {
+                        JCRUserNode targetUserNode = JahiaUserManagerService.getInstance().lookupUser(username);
+                        if (targetUserNode == null && resolvedUserSiteKey != null) {
+                            targetUserNode = JahiaUserManagerService.getInstance().lookupUser(username, resolvedUserSiteKey);
+                        }
+                        if (targetUserNode == null) {
+                            permCheckError = "User \"" + username
+                                    + "\" not found — cannot open a user session for hasPermission() check.";
+                        } else {
+                            JahiaUser targetUser = targetUserNode.getJahiaUser();
+                            JCRSessionFactory.getInstance().setCurrentUser(targetUser);
+                            userSession = JCRSessionFactory.getInstance().getCurrentUserSession(workspace, null, null);
+                            permGranted = userSession.getNode(nodePath).hasPermission(checkPermission);
+                        }
+                    } catch (RepositoryException e) {
+                        permCheckError = "Permission check failed: " + e.getMessage();
+                        logger.debug("Unable to check permission {} for user {} on {}", checkPermission, username,
+                                nodePath, e);
+                    } finally {
+                        logoutSession(userSession);
+                        JCRSessionFactory.getInstance().setCurrentUser(previousUser);
+                    }
+                }
+
+                Map<String, String> grantingPrivToVia = buildGrantingPrivilegeMap(systemSession, checkPermission);
+                for (RoleResult roleResult : roleResults) {
+                    addPermCheckMatches(roleResult, grantingPrivToVia, highlightedPerms, permCheckMatches);
+                }
+            }
+
+            return new Result(roleResults, permGranted, permCheckError, permCheckMatches, highlightedPerms);
+        }  finally {
+            logoutSession(editSession);
+            logoutSession(systemSession);
+        }
+    }
+
+    /**
+     * Populates {@code nodePerms} and {@code sitePerms} from the given role node and its parent
+     * roles (traversed recursively to inherit permissions from parent {@code jnt:role} nodes).
+     *
+     * <p>Permissions can be stored in two ways on a role node:
+     * <ul>
+     *   <li>{@code j:permissionNames} (STRING multi-value) — preferred; permission names are
+     *       expanded via {@link PermissionExpander}.</li>
+     *   <li>{@code j:permissions} (REFERENCE multi-value) — legacy; UUIDs referencing
+     *       {@code jnt:permission} nodes; the tree is walked directly.</li>
+     * </ul>
+     *
+     * <p>Child nodes of type {@code jnt:externalPermissions} are collected into
+     * {@code sitePerms}, one {@link SitePermGroup} per child.  If the same group name appears in
+     * a parent role and the child role, the child's version replaces the parent's (more specific
+     * definition wins).
+     *
+     * @param roleNode  the role node to collect permissions from
+     * @param session   JCR session for resolving permission nodes (edit workspace system session)
+     * @param nodePerms accumulator for node-level permissions
+     * @param sitePerms accumulator for site-level permission groups
+     */
+    private void collectRolePermissions(Node roleNode, Session session, List<PermissionEntry> nodePerms,
+            List<SitePermGroup> sitePerms) throws RepositoryException {
+        Node parent = roleNode.getParent();
+        if (parent.isNodeType(ROLE_NODE_TYPE)) {
+            collectRolePermissions(parent, session, nodePerms, sitePerms);
+        }
+
+        if (roleNode.hasProperty("j:permissionNames")) {
+            for (Value value : roleNode.getProperty("j:permissionNames").getValues()) {
+                addPermissionEntries(nodePerms, PermissionExpander.expand(value.getString(), session));
+            }
+        } else if (roleNode.hasProperty("j:permissions")) {
+            for (Value value : roleNode.getProperty("j:permissions").getValues()) {
+                try {
+                    Node permissionNode = session.getNodeByIdentifier(value.getString());
+                    addPermissionTree(permissionNode, nodePerms);
+                } catch (RepositoryException e) {
+                    logger.debug("Unable to resolve node-level permission {} for role {}", value.getString(),
+                            roleNode.getPath(), e);
+                }
+            }
+        }
+
+        NodeIterator children = roleNode.getNodes();
+        while (children.hasNext()) {
+            Node child = children.nextNode();
+            if (!child.isNodeType("jnt:externalPermissions")) {
+                continue;
+            }
+
+            String groupName = child.getName();
+            String targetPath = child.hasProperty("j:path") ? child.getProperty("j:path").getString() : "(unknown)";
+            List<PermissionEntry> permissions = new ArrayList<>();
+            if (child.hasProperty("j:permissionNames")) {
+                for (Value value : child.getProperty("j:permissionNames").getValues()) {
+                    addPermissionEntries(permissions, PermissionExpander.expand(value.getString(), session));
+                }
+            } else if (child.hasProperty("j:permissions")) {
+                for (Value value : child.getProperty("j:permissions").getValues()) {
+                    try {
+                        Node permissionNode = session.getNodeByIdentifier(value.getString());
+                        addPermissionTree(permissionNode, permissions);
+                    } catch (RepositoryException e) {
+                        logger.debug("Unable to resolve site permission {} for role {}", value.getString(),
+                                roleNode.getPath(), e);
+                    }
+                }
+            }
+
+            SitePermGroup replacement = new SitePermGroup(groupName, targetPath, permissions);
+            boolean replaced = false;
+            for (int i = 0; i < sitePerms.size(); i++) {
+                if (groupName.equals(sitePerms.get(i).getName())) {
+                    sitePerms.set(i, replacement);
+                    replaced = true;
+                    break;
+                }
+            }
+            if (!replaced) {
+                sitePerms.add(replacement);
+            }
+        }
+    }
+
+    /**
+     * Looks up {@code perm} in the map of privileges that grant the queried permission, trying
+     * three forms in order:
+     * <ol>
+     *   <li>Exact match (e.g. {@code jcr:read_default}).</li>
+     *   <li>After stripping the namespace prefix (e.g. {@code read_default}).</li>
+     *   <li>After taking only the last path segment (e.g. {@code deletePageAction} from a
+     *       hierarchical path like {@code /jContentActions/pageTreeActions/deletePageAction}).</li>
+     * </ol>
+     *
+     * @param grantingPrivToVia map from privilege name to an explanatory "via" string; an empty
+     *                          string means the permission matched directly
+     * @param perm              the permission path or name to look up
+     * @return the "via" explanation string (possibly empty) if a match is found, or {@code null}
+     */
+    private String lookupPerm(Map<String, String> grantingPrivToVia, String perm) {
+        String via = grantingPrivToVia.get(perm);
+        if (via != null) {
+            return via;
+        }
+        if (perm.contains(":")) {
+            via = grantingPrivToVia.get(perm.substring(perm.indexOf(':') + 1));
+            if (via != null) {
+                return via;
+            }
+        }
+        if (perm.contains("/")) {
+            via = grantingPrivToVia.get(perm.substring(perm.lastIndexOf('/') + 1));
+            return via;
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether the given ACL principal string matches the inspected user or group.
+     *
+     * <p>Matching rules:
+     * <ul>
+     *   <li>If {@code usernameOrGroup} starts with {@code g:}, match only when the ACL
+     *       {@code principal} refers to the same group (using flexible {@link #principalsMatch}).</li>
+     *   <li>{@code u:username} — matches when the username is equal.</li>
+     *   <li>{@code g:guests} — always matches (every visitor is a guest).</li>
+     *   <li>{@code g:users} / {@code g:site-users} — matches every non-guest user.</li>
+     *   <li>Any other group — delegates to
+     *       {@link JahiaGroupManagerService#isMember(String, String, String, String)}, checking
+     *       both the site group and the global group (site key {@code null}).</li>
+     * </ul>
+     *
+     * @param usernameOrGroup username or group principal (prefixed {@code g:}) being inspected
+     * @param siteKey         site key used for group membership resolution, may be {@code null}
+     * @param principal       principal string from the ACL entry (prefixed {@code u:} or {@code g:})
+     * @param groupMgr        group manager service instance
+     * @return {@code true} if the principal applies to the given user or group
+     */
+    private boolean matchesPrincipal(String usernameOrGroup, String siteKey, String principal,
+            JahiaGroupManagerService groupMgr) {
+        // When the input itself is a group principal, only match the exact same group.
+        if (usernameOrGroup.startsWith("g:")) {
+            return principalsMatch(usernameOrGroup, principal);
+        }
+        if (principal.startsWith("u:")) {
+            return usernameOrGroup.equals(principal.substring(2));
+        }
+        if (!principal.startsWith("g:")) {
+            return false;
+        }
+
+        String groupName = principal.substring(2);
+        if (JahiaGroupManagerService.GUEST_GROUPNAME.equals(groupName)) {
+            return true;
+        }
+        if (JahiaGroupManagerService.USERS_GROUPNAME.equals(groupName)
+                || JahiaGroupManagerService.SITE_USERS_GROUPNAME.equals(groupName)) {
+            return !"guest".equals(usernameOrGroup);
+        }
+
+        try {
+            return groupMgr.isMember(usernameOrGroup, null, groupName, siteKey)
+                    || groupMgr.isMember(usernameOrGroup, null, groupName, null);
+        } catch (Exception e) {
+            logger.debug("Unable to resolve group membership for {} and {}", usernameOrGroup, principal, e);
+            return false;
+        }
+    }
+
+    /**
+     * Returns {@code true} when {@code effectiveRoles} already contains an entry whose clean role
+     * name equals {@code extBase} or starts with {@code extBase/} (child role).  Used as a
+     * lightweight guard to avoid re-adding a role that was already captured by a direct GRANT in
+     * Pass 1 — but note that Pass 2 still processes the {@code j:sourceAce} to discover any
+     * additional content nodes not already represented.
+     *
+     * @param effectiveRoles current effective-role map (may contain {@code §N} suffixed keys)
+     * @param extBase        base role name (without any {@code /extPermName} suffix)
+     * @return {@code true} if the role is already present in the map
+     */
+    private boolean isAlreadyCovered(Map<String, String[]> effectiveRoles, String extBase) {
+        for (String key : effectiveRoles.keySet()) {
+            String cleanKey = stripDuplicateSuffix(key);
+            if (cleanKey.equals(extBase) || cleanKey.startsWith(extBase + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Resolves the content node(s) where the role was originally granted by iterating the
+     * {@code j:sourceAce} multi-valued REFERENCE property on the matching {@code jnt:externalAce}
+     * at the site node's {@code j:acl}.
+     *
+     * <p>Each {@code j:sourceAce} value is a REFERENCE or WEAKREFERENCE UUID pointing to an ACE
+     * node ({@code jnt:ace}) on the content node's {@code j:acl}.  Navigating
+     * {@code sourceAce → parent (j:acl) → parent} yields the content node path.
+     *
+     * <p>Matching strategy for the {@code jnt:externalAce}:
+     * <ol>
+     *   <li>Node type must be {@code jnt:externalAce}.</li>
+     *   <li>{@code j:principal} must match {@code extPrincipal} via {@link #principalsMatch}
+     *       (flexible to handle site-qualified group names).</li>
+     *   <li>{@code j:roles} (NAME multi-value) must contain the base role name {@code extBase}.</li>
+     * </ol>
+     *
+     * <p>The method does NOT add a fallback path; callers are responsible for handling an empty
+     * result.
+     *
+     * @param systemSession JCR system session (workspace being analysed)
+     * @param extPrincipal  principal from the EXTERNAL ACL entry (e.g. {@code g:sample-group})
+     * @param extGrantPath  path of the site node where the {@code jnt:externalAce} lives
+     * @param extBase       base role name (e.g. {@code translator-en})
+     * @return distinct content node paths resolved from {@code j:sourceAce}; empty if none found
+     */
+    private List<String> resolveExternalContentPaths(JCRSessionWrapper systemSession,
+            String extPrincipal, String extGrantPath, String extBase) {
+        List<String> contentPaths = new ArrayList<>();
+        try {
+            if (systemSession.nodeExists(extGrantPath)) {
+                JCRNodeWrapper siteNode = systemSession.getNode(extGrantPath);
+                if (siteNode.hasNode("j:acl")) {
+                    NodeIterator aclChildren = siteNode.getNode("j:acl").getNodes();
+                    while (aclChildren.hasNext()) {
+                        Node aceNode = aclChildren.nextNode();
+                        if (!aceNode.isNodeType("jnt:externalAce")) {
+                            continue;
+                        }
+                        String acePrincipal = aceNode.hasProperty("j:principal")
+                                ? aceNode.getProperty("j:principal").getString() : null;
+                        if (!principalsMatch(extPrincipal, acePrincipal)) {
+                            continue;
+                        }
+                        if (aceNode.hasProperty("j:roles") && !matchesExternalRole(extBase, aceNode)) {
+                            continue;
+                        }
+                        if (!aceNode.hasProperty("j:sourceAce")) {
+                            continue;
+                        }
+                        for (Value sourceAceValue : aceNode.getProperty("j:sourceAce").getValues()) {
+                            try {
+                                Node sourceAce = sourceAceValue.getType() == PropertyType.REFERENCE
+                                        || sourceAceValue.getType() == PropertyType.WEAKREFERENCE
+                                                ? systemSession.getNodeByIdentifier(sourceAceValue.getString())
+                                                : systemSession.getNode(sourceAceValue.getString());
+                                addIfMissing(contentPaths, sourceAce.getParent().getParent().getPath());
+                            } catch (RepositoryException e) {
+                                logger.debug("Unable to resolve source ACE {} for {}", sourceAceValue,
+                                        extGrantPath, e);
+                            }
+                        }
+                        // No break — a site j:acl could theoretically have multiple matching
+                        // jnt:externalAce nodes; collect all their source paths.
+                    }
+                }
+            }
+        } catch (RepositoryException e) {
+            logger.debug("Unable to resolve external ACE sources for {}", extGrantPath, e);
+        }
+        return contentPaths;
+    }
+
+    /**
+     * Compares two principal strings for equality, with a fallback that compares only the local
+     * part (after the last {@code :}) to accommodate site-qualified group names.
+     *
+     * <p>Example: {@code "g:digitall:sample-group"} and {@code "g:sample-group"} are considered
+     * equal because both have the local name {@code sample-group}.
+     *
+     * @param p1 first principal; {@code null} returns {@code false}
+     * @param p2 second principal; {@code null} returns {@code false}
+     * @return {@code true} if the principals refer to the same user or group
+     */
+    private boolean principalsMatch(String p1, String p2) {
+        if (p1 == null || p2 == null) {
+            return false;
+        }
+        if (p1.equals(p2)) {
+            return true;
+        }
+        String local1 = p1.substring(p1.lastIndexOf(':') + 1);
+        String local2 = p2.substring(p2.lastIndexOf(':') + 1);
+        return local1.equals(local2);
+    }
+
+    /**
+     * Returns {@code true} when {@code effectiveRoles} already contains an entry for role
+     * {@code extBase} (or a child of it) with exactly {@code contentPath} as the grant path.
+     * Used to prevent adding duplicate {@link RoleResult} entries when the same content path is
+     * discovered both via a direct GRANT (Pass 1) and via {@code j:sourceAce} (Pass 2).
+     *
+     * @param effectiveRoles current effective-role map
+     * @param extBase        base role name to check
+     * @param contentPath    content node path to check for
+     * @return {@code true} if the (role, path) combination is already present
+     */
+    private boolean isPathCoveredForRole(Map<String, String[]> effectiveRoles, String extBase, String contentPath) {
+        for (Map.Entry<String, String[]> entry : effectiveRoles.entrySet()) {
+            String cleanKey = stripDuplicateSuffix(entry.getKey());
+            if ((cleanKey.equals(extBase) || cleanKey.startsWith(extBase + "/"))
+                    && contentPath.equals(entry.getValue()[0])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the next available map key for {@code base} in {@code effectiveRoles}.
+     * Returns {@code base} itself when that key is absent; otherwise returns
+     * {@code base§1}, {@code base§2}, etc., incrementing until a free slot is found.
+     *
+     * @param effectiveRoles map to check for key collisions
+     * @param base           base role name
+     * @return unique key to use for a new entry
+     */
+    private String findUniqueKey(Map<String, String[]> effectiveRoles, String base) {
+        if (!effectiveRoles.containsKey(base)) {
+            return base;
+        }
+        int n = 1;
+        while (effectiveRoles.containsKey(base + ROLE_DUPLICATE_SEPARATOR + n)) {
+            n++;
+        }
+        return base + ROLE_DUPLICATE_SEPARATOR + n;
+    }
+
+    /**
+     * Finds the existing map key in {@code effectiveRoles} whose base role name (after stripping
+     * the {@link #ROLE_DUPLICATE_SEPARATOR} suffix) equals {@code roleName} AND whose stored
+     * principal (index 2 of the value array) matches {@code principal}.
+     *
+     * <p>This allows Pass 1 to treat each (role, principal) pair independently: a deeper grant
+     * for the same principal updates the existing entry, while a grant from a different principal
+     * always gets its own card.
+     *
+     * @param effectiveRoles current effective-role accumulator
+     * @param roleName       base role name to look for (without suffix)
+     * @param principal      principal string to match exactly
+     * @return the matching key, or {@code null} if none exists yet
+     */
+    private String findKeyForRoleAndPrincipal(Map<String, String[]> effectiveRoles,
+            String roleName, String principal) {
+        for (Map.Entry<String, String[]> entry : effectiveRoles.entrySet()) {
+            if (stripDuplicateSuffix(entry.getKey()).equals(roleName)
+                    && principal.equals(entry.getValue()[2])) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether the {@code j:roles} NAME multi-value property of a {@code jnt:externalAce}
+     * node contains {@code extBase} (exact match or local-name match after stripping any path
+     * prefix).
+     *
+     * @param extBase base role name to look for (e.g. {@code translator-en})
+     * @param aceNode {@code jnt:externalAce} node whose {@code j:roles} property is read
+     * @return {@code true} if the role is listed on the external ACE
+     */
+    private boolean matchesExternalRole(String extBase, Node aceNode) throws RepositoryException {
+        for (Value value : aceNode.getProperty("j:roles").getValues()) {
+            String roleValue = value.getString();
+            String localValue = roleValue.contains("/") ? roleValue.substring(roleValue.lastIndexOf('/') + 1)
+                    : roleValue;
+            if (extBase.equals(roleValue) || extBase.equals(localValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Resolves the {@code jnt:role} definition node for the given role name using the
+     * {@code default} workspace system session.
+     *
+     * <p>Lookup strategy:
+     * <ol>
+     *   <li>Try {@code /roles/{roleName}} directly (handles nested roles like
+     *       {@code translator/translator-en}).</li>
+     *   <li>Fall back to a JCR-SQL2 query on {@code localname() = localPart} under
+     *       {@code /roles} (handles roles whose path is unknown but whose local name is unique).
+     *       </li>
+     * </ol>
+     *
+     * @param editSession JCR system session in the {@code default} workspace
+     * @param roleName    role name as returned by the ACL entry, e.g. {@code translator-en} or
+     *                    {@code translator/translator-en}
+     * @return the role node, or {@code null} if it cannot be found
+     */
+    private Node resolveRoleNode(Session editSession, String roleName) {
+        try {
+            String fullRolePath = "/roles/" + roleName;
+            if (editSession.nodeExists(fullRolePath)) {
+                return editSession.getNode(fullRolePath);
+            }
+
+            String localName = roleName.contains("/") ? roleName.substring(roleName.lastIndexOf('/') + 1) : roleName;
+            NodeIterator roleNodes = editSession.getWorkspace().getQueryManager().createQuery(
+                    "select * from [" + ROLE_NODE_TYPE + "] as r where localname()='"
+                            + JCRContentUtils.sqlEncode(localName)
+                            + "' and isdescendantnode(r,['/roles'])",
+                    Query.JCR_SQL2).execute().getNodes();
+            if (roleNodes.hasNext()) {
+                return roleNodes.nextNode();
+            }
+        } catch (RepositoryException e) {
+            logger.debug("Unable to resolve role node for {}", roleName, e);
+        }
+        return null;
+    }
+
+    /**
+     * Builds a map of privilege names (and their local variants) that would grant the queried
+     * permission, keyed by privilege name with the value being a human-readable "via" explanation.
+     *
+     * <p>The map is pre-seeded with the queried permission and its local (namespace-stripped)
+     * form.  It is then expanded by iterating all registered Jahia privileges and checking
+     * whether any of them aggregate the target privilege — if so, the aggregate privilege is
+     * also added with a {@code "via aggregate privilege: …"} note.
+     *
+     * <p>This expansion is necessary because a role may declare a broad aggregate privilege
+     * (e.g. {@code jcr:write}) without explicitly listing the narrower permission being queried
+     * (e.g. {@code jcr:modifyProperties}).
+     *
+     * @param systemSession JCR system session used to obtain the {@code AccessControlManager}
+     * @param checkPermission permission name to expand
+     * @return map from privilege name / local name to explanation; never {@code null}
+     */
+    private Map<String, String> buildGrantingPrivilegeMap(JCRSessionWrapper systemSession, String checkPermission) {
+        Map<String, String> grantingPrivToVia = new LinkedHashMap<>();
+        grantingPrivToVia.put(checkPermission, "");
+        String checkPermLocal = checkPermission.contains(":")
+                ? checkPermission.substring(checkPermission.indexOf(':') + 1)
+                : checkPermission;
+        if (!checkPermLocal.equals(checkPermission)) {
+            grantingPrivToVia.put(checkPermLocal, "");
+        }
+
+        try {
+            AccessControlManager accessControlManager = systemSession.getAccessControlManager();
+            Privilege targetPrivilege = accessControlManager.privilegeFromName(checkPermission);
+            grantingPrivToVia.put(targetPrivilege.getName(), "");
+
+            for (String registeredName : JahiaPrivilegeRegistry.getRegisteredPrivilegeNames()) {
+                try {
+                    Privilege registeredPrivilege = accessControlManager.privilegeFromName(registeredName);
+                    if (grantingPrivToVia.containsKey(registeredPrivilege.getName())) {
+                        continue;
+                    }
+                    for (Privilege aggregatePrivilege : registeredPrivilege.getAggregatePrivileges()) {
+                        if (aggregatePrivilege.equals(targetPrivilege)) {
+                            String via = "via aggregate privilege: " + registeredName;
+                            grantingPrivToVia.put(registeredPrivilege.getName(), via);
+                            grantingPrivToVia.put(registeredName, via);
+                            String aggregateLocal = registeredName.contains(":")
+                                    ? registeredName.substring(registeredName.indexOf(':') + 1)
+                                    : registeredName;
+                            grantingPrivToVia.put(aggregateLocal, via);
+                            break;
+                        }
+                    }
+                } catch (RepositoryException e) {
+                    logger.debug("Unable to inspect aggregate privilege {}", registeredName, e);
+                }
+            }
+        } catch (RepositoryException e) {
+            logger.debug("Unable to expand aggregate privileges for {}", checkPermission, e);
+        }
+        return grantingPrivToVia;
+    }
+
+    /**
+     * Scans the node-level and site-level permissions of {@code roleResult} for entries that
+     * appear in {@code grantingPrivToVia}.  For each match, one {@link PermCheckMatch} is added
+     * to {@code permCheckMatches} and the matching permission path is recorded in
+     * {@code highlightedPerms} for visual emphasis in the view.
+     *
+     * <p>Only the first matching permission per category (node vs site) is recorded to avoid
+     * duplicating matches when both a parent and a child permission appear in the list.
+     *
+     * @param roleResult          role whose permissions are scanned
+     * @param grantingPrivToVia   map built by {@link #buildGrantingPrivilegeMap}
+     * @param highlightedPerms    set to accumulate highlighted permission paths
+     * @param permCheckMatches    list to accumulate match records
+     */
+    private void addPermCheckMatches(RoleResult roleResult, Map<String, String> grantingPrivToVia,
+            Set<String> highlightedPerms, List<PermCheckMatch> permCheckMatches) {
+        for (PermissionEntry permission : roleResult.getNodePermissions()) {
+            String via = lookupPerm(grantingPrivToVia, permission.getPath());
+            if (via != null) {
+                highlightedPerms.add(permission.getPath());
+                permCheckMatches.add(new PermCheckMatch(roleResult.getRoleName(), roleResult.getContentGrantPath(),
+                        roleResult.getGrantType(), "node", via, roleResult.getContentEditorUrl()));
+                break;
+            }
+        }
+
+        for (SitePermGroup sitePermGroup : roleResult.getSitePermissions()) {
+            for (PermissionEntry permission : sitePermGroup.getPermissions()) {
+                String via = lookupPerm(grantingPrivToVia, permission.getPath());
+                if (via != null) {
+                    highlightedPerms.add(permission.getPath());
+                    String detail = sitePermGroup.getName() + " on " + sitePermGroup.getTargetPath()
+                            + (via.isEmpty() ? "" : " (" + via + ")");
+                    permCheckMatches.add(new PermCheckMatch(roleResult.getRoleName(), roleResult.getContentGrantPath(),
+                            roleResult.getGrantType(), "site", detail, roleResult.getContentEditorUrl()));
+                    break;
+                }
+            }
+        }
+    }
+
+    /** Adds all entries from {@code additions} to {@code target}, skipping duplicates by path. */
+    private void addPermissionEntries(List<PermissionEntry> target, List<PermissionEntry> additions) {
+        for (PermissionEntry addition : additions) {
+            addIfMissing(target, addition);
+        }
+    }
+
+    /**
+     * Convenience wrapper that strips the {@code /permissions} prefix from a permission node's
+     * path and delegates to {@link #collectPermissionTree} for recursive collection.
+     */
+    private void addPermissionTree(Node permissionNode, List<PermissionEntry> target) {
+        try {
+            String relativePath = permissionNode.getPath().startsWith("/permissions")
+                    ? permissionNode.getPath().substring("/permissions".length())
+                    : permissionNode.getPath();
+            collectPermissionTree(permissionNode, relativePath, target);
+        } catch (RepositoryException e) {
+            logger.debug("Unable to collect permission tree for {}", permissionNode, e);
+        }
+    }
+
+    /**
+     * Recursively walks the {@code jnt:permission} subtree rooted at {@code permissionNode},
+     * adding a {@link PermissionEntry} for each node (including the root) to {@code target}.
+     */
+    private void collectPermissionTree(Node permissionNode, String relativePath, List<PermissionEntry> target)
+            throws RepositoryException {
+        addIfMissing(target, new PermissionEntry(relativePath));
+        NodeIterator children = permissionNode.getNodes();
+        while (children.hasNext()) {
+            Node child = children.nextNode();
+            if (child.isNodeType("jnt:permission")) {
+                collectPermissionTree(child, relativePath + "/" + child.getName(), target);
+            }
+        }
+    }
+
+    /**
+     * Strips the {@code §N} duplicate suffix from a role map key, returning the clean base name.
+     * E.g. {@code "translator-en§2"} → {@code "translator-en"}.
+     */
+    private String stripDuplicateSuffix(String value) {
+        int separatorIndex = value.indexOf(ROLE_DUPLICATE_SEPARATOR);
+        return separatorIndex >= 0 ? value.substring(0, separatorIndex) : value;
+    }
+
+    /**
+     * Extracts the site key from a node path of the form {@code /sites/{siteKey}/…}.
+     *
+     * @param nodePath absolute JCR path
+     * @return site key, or {@code null} if the path does not start with {@code /sites/}
+     */
+    private String extractSiteKey(String nodePath) {
+        if (nodePath == null || !nodePath.startsWith("/sites/")) {
+            return null;
+        }
+        String remaining = nodePath.substring("/sites/".length());
+        int separatorIndex = remaining.indexOf('/');
+        return separatorIndex >= 0 ? remaining.substring(0, separatorIndex) : remaining;
+    }
+
+    /**
+     * Builds the server base URL ({@code scheme://host[:port]}) from the current HTTP request,
+     * omitting the port suffix for the standard ports 80 and 443.
+     *
+     * @param request current HTTP request; {@code null} returns {@code null}
+     * @return server base URL, or {@code null}
+     */
+    private String buildServerBase(HttpServletRequest request) {
+        if (request == null) {
+            return null;
+        }
+        int port = request.getServerPort();
+        String portSuffix = port == 80 || port == 443 ? "" : ":" + port;
+        return request.getScheme() + "://" + request.getServerName() + portSuffix;
+    }
+
+    /** Adds {@code value} to {@code target} only if the list does not already contain it. */
+    private void addIfMissing(List<String> target, String value) {
+        if (!target.contains(value)) {
+            target.add(value);
+        }
+    }
+
+    /** Adds {@code value} to {@code target} only if no entry with the same path already exists. */
+    private void addIfMissing(List<PermissionEntry> target, PermissionEntry value) {
+        for (PermissionEntry entry : target) {
+            if (entry.getPath().equals(value.getPath())) {
+                return;
+            }
+        }
+        target.add(value);
+    }
+
+    /** Safely logs out a JCR session, ignoring {@code null} and already-closed sessions. */
+    private void logoutSession(Session session) {
+        if (session == null) {
+            return;
+        }
+        try {
+            if (session.isLive()) {
+                session.logout();
+            }
+        } catch (Exception e) {
+            logger.debug("Unable to close JCR session", e);
+        }
+    }
+}

--- a/impl/src/main/resources/css/userPermissions.css
+++ b/impl/src/main/resources/css/userPermissions.css
@@ -1,0 +1,362 @@
+/* Search panel */
+.search-panel {
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 6px;
+    padding: 16px 20px 12px;
+    margin-bottom: 24px;
+}
+
+.search-panel h3 {
+    margin: 0 0 12px 0;
+    font-size: 0.95em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #495057;
+}
+
+.form-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 16px;
+    align-items: flex-end;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.form-field-wide {
+    flex: 1;
+    min-width: 240px;
+}
+
+.form-field-username {
+    min-width: 160px;
+}
+
+.form-field-site {
+    min-width: 160px;
+}
+
+.form-field-workspace {
+    min-width: 120px;
+}
+
+.form-field label {
+    font-size: 0.78em;
+    font-weight: bold;
+    color: #6c757d;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.form-field input[type="text"],
+.form-field select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    font-size: 0.93em;
+    background: #fff;
+}
+
+.form-field input[type="text"]:focus,
+.form-field select:focus {
+    outline: none;
+    border-color: #293136;
+    box-shadow: 0 0 0 2px rgba(41, 49, 54, 0.15);
+}
+
+.form-field input[type="submit"] {
+    padding: 7px 22px;
+    background: #293136;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.93em;
+    white-space: nowrap;
+}
+
+.form-field input[type="submit"]:hover {
+    background: #404f57;
+}
+
+.perm-check-result {
+    margin: 16px 0;
+    padding: 14px 18px;
+    border-radius: 4px;
+    font-size: 1.05em;
+}
+
+.perm-check-granted {
+    background: #d4edda;
+    border: 1px solid #28a745;
+    color: #155724;
+}
+
+.perm-check-denied {
+    background: #f8d7da;
+    border: 1px solid #dc3545;
+    color: #721c24;
+}
+
+.perm-check-result strong {
+    font-size: 1.1em;
+}
+
+.perm-check-detail {
+    margin-top: 8px;
+    font-size: 0.9em;
+}
+
+.perm-check-detail table {
+    margin-top: 6px;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.perm-check-detail th {
+    text-align: left;
+    padding: 4px 10px;
+    background: rgba(0, 0, 0, 0.08);
+    white-space: nowrap;
+}
+
+.perm-check-detail td {
+    padding: 4px 10px;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    vertical-align: top;
+}
+
+.tag-grant {
+    background: #d4edda;
+    color: #155724;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.85em;
+    font-weight: bold;
+}
+
+.tag-deny {
+    background: #f8d7da;
+    color: #721c24;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.85em;
+    font-weight: bold;
+}
+
+.tag-external {
+    background: #fff3cd;
+    color: #856404;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.85em;
+    font-weight: bold;
+}
+
+.perm-list {
+    margin: 0;
+    padding: 0 0 0 16px;
+}
+
+.perm-section + .perm-section {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed #cfcfcf;
+}
+
+.perm-section-label {
+    font-size: 0.8em;
+    color: #666;
+    margin-bottom: 2px;
+}
+
+.no-perm {
+    color: #999;
+    font-style: italic;
+}
+
+.no-results {
+    color: #856404;
+    background: #fff3cd;
+    padding: 12px;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    margin-top: 16px;
+}
+
+.error-msg {
+    color: #721c24;
+    background: #f8d7da;
+    padding: 12px;
+    border: 1px solid #f5c6cb;
+    border-radius: 4px;
+    margin-top: 16px;
+}
+
+.section-title {
+    font-size: 1.1em;
+    font-weight: bold;
+    margin: 24px 0 8px 0;
+    padding-bottom: 4px;
+    border-bottom: 2px solid #293136;
+}
+
+.highlight-perm {
+    background: #fff3cd;
+    font-weight: bold;
+}
+
+/* Permission expand (+ toggle) */
+details.perm-detail {
+    display: inline;
+}
+
+details.perm-detail > summary {
+    display: inline;
+    list-style: none;
+    cursor: pointer;
+}
+
+details.perm-detail > summary::-webkit-details-marker {
+    display: none;
+}
+
+details.perm-detail > summary::after {
+    content: ' +';
+    font-size: 0.75em;
+    color: #888;
+    font-style: normal;
+}
+
+details.perm-detail[open] > summary::after {
+    content: ' \2212';
+}
+
+details.perm-detail .perm-full-path {
+    display: block;
+    font-size: 0.78em;
+    color: #666;
+    font-family: monospace;
+    margin-top: 1px;
+}
+
+/* Role result cards */
+.role-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 8px;
+}
+
+.role-card {
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: 0.88em;
+}
+
+.role-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 12px;
+    background: #f6f8fa;
+    border-bottom: 1px solid #d0d7de;
+    flex-wrap: wrap;
+}
+
+.role-card-header .role-name {
+    font-weight: bold;
+    font-size: 1em;
+}
+
+.role-card-header .role-principal {
+    font-family: monospace;
+    font-size: 0.85em;
+    color: #444;
+    background: #f0f0f0;
+    border: 1px solid #d0d0d0;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+.role-card-header .role-principal-group {
+    background: #dbeafe;
+    color: #1d4ed8;
+    border-color: #93c5fd;
+}
+
+.role-card-header .role-tag {
+    margin-left: auto;
+}
+
+.role-card-meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 2px 8px;
+    padding: 6px 12px;
+    border-bottom: 1px solid #eaecef;
+    background: #fff;
+    font-size: 0.9em;
+}
+
+.role-card-meta .meta-label {
+    color: #888;
+    white-space: nowrap;
+    align-self: center;
+}
+
+.role-card-perms {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    background: #fff;
+}
+
+.perm-col {
+    padding: 8px 12px;
+}
+
+.perm-col + .perm-col {
+    border-left: 1px solid #eaecef;
+}
+
+.perm-col-title {
+    font-size: 0.78em;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #666;
+    margin-bottom: 4px;
+}
+
+.grant-node-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+a.edit-link {
+    display: inline-block;
+    padding: 1px 7px;
+    background: #e9ecef;
+    border: 1px solid #ced4da;
+    border-radius: 3px;
+    font-size: 0.8em;
+    text-decoration: none;
+    color: #495057;
+    white-space: nowrap;
+    line-height: 1.6;
+}
+
+a.edit-link:hover {
+    background: #dee2e6;
+    color: #212529;
+}

--- a/impl/src/main/resources/index.jsp
+++ b/impl/src/main/resources/index.jsp
@@ -77,6 +77,7 @@
                     <li><a href="jobadmin.jsp">Background job administration</a></li>
                     <li><a href="search.jsp">Search engine management</a></li>
                     <li><a href="dbQuery.jsp">DB query tool</a></li>
+                    <li><a href="userPermissions.jsp">User permissions inspector</a></li>
                     <li><a href="groovyConsole.jsp">Groovy console</a></li>
                     <li><a href="workflows.jsp">Workflow monitoring</a></li>
                     <li><a href="rules.jsp">Business rules</a></li>

--- a/impl/src/main/resources/userPermissions.jsp
+++ b/impl/src/main/resources/userPermissions.jsp
@@ -1,0 +1,346 @@
+<%@ page contentType="text/html; charset=UTF-8"%>
+<%@ page import="org.jahia.modules.tools.userpermissions.UserPermissionsAnalyzer,org.jahia.modules.tools.userpermissions.UserPermissionsAnalyzer.Result" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
+<!DOCTYPE html>
+<html>
+<%
+    String selectedWorkspace = request.getParameter("workspace");
+    if (selectedWorkspace == null || selectedWorkspace.trim().isEmpty()) {
+        selectedWorkspace = "default";
+    }
+    pageContext.setAttribute("selectedWorkspace", selectedWorkspace);
+    pageContext.setAttribute("checkPermissionParam", request.getParameter("checkPermission"));
+    java.util.List<String> allPrivilegeNames = new java.util.ArrayList<>(
+            org.apache.jackrabbit.core.security.JahiaPrivilegeRegistry.getRegisteredPrivilegeNames());
+    java.util.Collections.sort(allPrivilegeNames);
+    pageContext.setAttribute("allPrivilegeNames", allPrivilegeNames);
+
+    // Load available site keys for the site selector
+    try {
+        org.jahia.services.content.JCRSessionWrapper siteSession =
+            org.jahia.services.content.JCRSessionFactory.getInstance().getCurrentSystemSession("default", null, null);
+        javax.jcr.NodeIterator siteIt = siteSession.getNode("/sites").getNodes();
+        java.util.List<String> siteKeys = new java.util.ArrayList<>();
+        while (siteIt.hasNext()) {
+            javax.jcr.Node sn = siteIt.nextNode();
+            if (sn.isNodeType("jnt:virtualsite")) {
+                siteKeys.add(sn.getName());
+            }
+        }
+        java.util.Collections.sort(siteKeys);
+        pageContext.setAttribute("siteKeys", siteKeys);
+    } catch (Exception ignored) { /* site selector will be empty */ }
+
+    if (request.getParameter("username") != null && !request.getParameter("username").trim().isEmpty()
+            && request.getParameter("nodePath") != null && !request.getParameter("nodePath").trim().isEmpty()) {
+        try {
+            Result analysisResult = new UserPermissionsAnalyzer().analyze(request.getParameter("username"),
+                    request.getParameter("nodePath"), selectedWorkspace, request.getParameter("checkPermission"),
+                    request.getParameter("userSite"), request);
+            pageContext.setAttribute("result", analysisResult);
+        } catch (javax.jcr.PathNotFoundException e) {
+            pageContext.setAttribute("errorMsg", "Node not found: " + request.getParameter("nodePath"));
+        } catch (Exception e) {
+            pageContext.setAttribute("errorMsg", e.getMessage());
+        }
+    }
+%>
+<c:set var="title" value="User Permissions Inspector"/>
+<head>
+    <%@ include file="commons/html_header.jspf" %>
+    <%@ include file="css.jspf" %>
+    <link rel="stylesheet" href="<c:url value='/modules/tools/css/userPermissions.css'/>" type="text/css" />
+</head>
+<body>
+<%@ include file="commons/header.jspf" %>
+
+<div class="search-panel">
+    <h3>Inspect user permissions on a node</h3>
+    <form class="permissions-form" action="?" method="get">
+        <input type="hidden" name="toolAccessToken" value="${toolAccessToken}"/>
+        <div class="form-grid">
+            <div class="form-field form-field-username">
+                <label for="username">Username or group</label>
+                <input type="text" id="username" name="username" value="${fn:escapeXml(param.username)}"
+                       placeholder="username or g:groupname"/>
+            </div>
+            <div class="form-field form-field-site">
+                <label for="userSite">Site (user/group lookup)</label>
+                <select id="userSite" name="userSite">
+                    <option value="">(global)</option>
+                    <c:forEach var="sk" items="${siteKeys}">
+                        <option value="${fn:escapeXml(sk)}" <c:if test="${param.userSite == sk}">selected="selected"</c:if>>${fn:escapeXml(sk)}</option>
+                    </c:forEach>
+                </select>
+            </div>
+            <div class="form-field form-field-wide">
+                <label for="nodePath">Node path</label>
+                <input type="text" id="nodePath" name="nodePath" value="${fn:escapeXml(param.nodePath)}"
+                       placeholder="e.g. /sites/systemsite/home"/>
+            </div>
+            <div class="form-field form-field-workspace">
+                <label for="workspace">Workspace</label>
+                <select id="workspace" name="workspace">
+                    <option value="default" <c:if test="${selectedWorkspace == 'default'}">selected="selected"</c:if>>default</option>
+                    <option value="live" <c:if test="${selectedWorkspace == 'live'}">selected="selected"</c:if>>live</option>
+                </select>
+            </div>
+            <c:if test="${not empty allPrivilegeNames}">
+                <div class="form-field form-field-wide">
+                    <label for="checkPermission">Check permission</label>
+                    <select id="checkPermission" name="checkPermission">
+                        <option value="">(none — show all roles only)</option>
+                        <c:forEach var="privName" items="${allPrivilegeNames}">
+                            <option value="${fn:escapeXml(privName)}" <c:if test="${checkPermissionParam == privName}">selected="selected"</c:if>>${fn:escapeXml(privName)}</option>
+                        </c:forEach>
+                    </select>
+                </div>
+            </c:if>
+            <div class="form-field">
+                <label>&nbsp;</label>
+                <input type="submit" value="Inspect permissions"/>
+            </div>
+        </div>
+    </form>
+</div>
+
+<c:if test="${not empty param.username and not empty param.nodePath}">
+    <h2>Results for user <strong>${fn:escapeXml(param.username)}</strong> on node
+        <code>${fn:escapeXml(param.nodePath)}</code>
+        (workspace: <strong>${fn:escapeXml(selectedWorkspace)}</strong>)</h2>
+
+    <c:if test="${not empty errorMsg}">
+        <p class="error-msg" data-test-id="error-msg">${fn:escapeXml(errorMsg)}</p>
+    </c:if>
+
+    <c:if test="${not empty checkPermissionParam and empty errorMsg}">
+        <div class="section-title">Quick permission check</div>
+        <c:choose>
+            <c:when test="${not empty result.permCheckError}">
+                <div class="perm-check-result perm-check-denied">
+                    <strong>&#9888; Check unavailable</strong> &mdash; ${fn:escapeXml(result.permCheckError)}
+                </div>
+            </c:when>
+            <c:when test="${result.permGranted}">
+                <div class="perm-check-result perm-check-granted">
+                    <strong>&#10003; GRANTED</strong> &mdash;
+                    <code>${fn:escapeXml(checkPermissionParam)}</code> is granted to
+                    <strong>${fn:escapeXml(param.username)}</strong> on this node
+                    (confirmed by <code>JCRNodeWrapper.hasPermission()</code>).
+                    <c:if test="${not empty result.permCheckMatches}">
+                        <div class="perm-check-detail">
+                            <table>
+                                <thead>
+                                <tr>
+                                    <th>Role</th>
+                                    <th>Grant type</th>
+                                    <th>Content node (where role is granted)</th>
+                                    <th>Permission level</th>
+                                    <th>Details</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <c:forEach var="match" items="${result.permCheckMatches}">
+                                    <tr>
+                                        <td><strong>${fn:escapeXml(match.roleName)}</strong></td>
+                                        <td>
+                                            <c:choose>
+                                                <c:when test="${match.grantType == 'GRANT'}"><span class="tag-grant">GRANT</span></c:when>
+                                                <c:when test="${match.grantType == 'EXTERNAL'}"><span class="tag-external">EXTERNAL</span></c:when>
+                                                <c:otherwise><span class="tag-deny">DENY</span></c:otherwise>
+                                            </c:choose>
+                                        </td>
+                                        <td>
+                                            <div class="grant-node-row">
+                                                <code>${fn:escapeXml(match.grantPath)}</code>
+                                                <c:if test="${not empty match.contentEditorUrl}">
+                                                    <a href="${match.contentEditorUrl}" target="_blank" class="edit-link">&#9998;&nbsp;edit</a>
+                                                </c:if>
+                                            </div>
+                                        </td>
+                                        <td>${fn:escapeXml(match.level)}</td>
+                                        <td>${fn:escapeXml(empty match.detail ? '-' : match.detail)}</td>
+                                    </tr>
+                                </c:forEach>
+                                </tbody>
+                            </table>
+                        </div>
+                    </c:if>
+                    <c:if test="${empty result.permCheckMatches}">
+                        <div class="perm-check-detail">
+                            <em>The granting role could not be identified from the role analysis above
+                            (may be via an aggregate privilege not expanded in the role scan).</em>
+                        </div>
+                    </c:if>
+                </div>
+            </c:when>
+            <c:otherwise>
+                <div class="perm-check-result perm-check-denied">
+                    <strong>&#10007; NOT GRANTED</strong> &mdash;
+                    <code>${fn:escapeXml(checkPermissionParam)}</code> is not granted to
+                    <strong>${fn:escapeXml(param.username)}</strong> on this node
+                    (confirmed by <code>JCRNodeWrapper.hasPermission()</code>).
+                    <c:if test="${not empty result.permCheckMatches}">
+                        <div class="perm-check-detail">
+                            The following roles define this permission but it is effectively denied:
+                            <table>
+                                <thead>
+                                <tr>
+                                    <th>Role</th>
+                                    <th>Grant type</th>
+                                    <th>Content node (where role is granted)</th>
+                                    <th>Permission level</th>
+                                    <th>Details</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <c:forEach var="match" items="${result.permCheckMatches}">
+                                    <tr>
+                                        <td><strong>${fn:escapeXml(match.roleName)}</strong></td>
+                                        <td>
+                                            <c:choose>
+                                                <c:when test="${match.grantType == 'GRANT'}"><span class="tag-grant">GRANT</span></c:when>
+                                                <c:when test="${match.grantType == 'EXTERNAL'}"><span class="tag-external">EXTERNAL</span></c:when>
+                                                <c:otherwise><span class="tag-deny">DENY</span></c:otherwise>
+                                            </c:choose>
+                                        </td>
+                                        <td>
+                                            <div class="grant-node-row">
+                                                <code>${fn:escapeXml(match.grantPath)}</code>
+                                                <c:if test="${not empty match.contentEditorUrl}">
+                                                    <a href="${match.contentEditorUrl}" target="_blank" class="edit-link">&#9998;&nbsp;edit</a>
+                                                </c:if>
+                                            </div>
+                                        </td>
+                                        <td>${fn:escapeXml(match.level)}</td>
+                                        <td>${fn:escapeXml(empty match.detail ? '-' : match.detail)}</td>
+                                    </tr>
+                                </c:forEach>
+                                </tbody>
+                            </table>
+                        </div>
+                    </c:if>
+                </div>
+            </c:otherwise>
+        </c:choose>
+    </c:if>
+
+    <c:if test="${empty errorMsg}">
+        <div class="section-title">All effective roles and permissions</div>
+        <c:choose>
+            <c:when test="${empty result.roleResults}">
+                <p class="no-results" data-test-id="no-results">No permissions found for this user on this node.</p>
+            </c:when>
+            <c:otherwise>
+                <div class="role-cards" data-test-id="role-cards">
+                    <c:forEach var="roleResult" items="${result.roleResults}">
+                        <div class="role-card" data-test-id="role-card" data-role-name="${fn:escapeXml(roleResult.roleName)}">
+                            <div class="role-card-header">
+                                <span class="role-name" data-test-id="role-name">${fn:escapeXml(roleResult.roleName)}</span>
+                                <span class="role-principal <c:if test="${fn:startsWith(roleResult.matchedPrincipal, 'g:')}">role-principal-group</c:if>" data-test-id="role-principal">${fn:escapeXml(roleResult.matchedPrincipal)}</span>
+                                <span class="role-tag">
+                                <c:choose>
+                                    <c:when test="${roleResult.grantType == 'GRANT'}"><span class="tag-grant">GRANT</span></c:when>
+                                    <c:when test="${roleResult.grantType == 'DENY'}"><span class="tag-deny">DENY</span></c:when>
+                                    <c:otherwise><span class="tag-external">${fn:escapeXml(roleResult.grantType)}</span></c:otherwise>
+                                </c:choose>
+                                </span>
+                            </div>
+
+                            <div class="role-card-meta">
+                                <span class="meta-label">Content node</span>
+                                <div class="grant-node-row">
+                                    <code>${fn:escapeXml(roleResult.contentGrantPath)}</code>
+                                    <c:if test="${not empty roleResult.contentEditorUrl}">
+                                        <a href="${roleResult.contentEditorUrl}" target="_blank" class="edit-link">&#9998;&nbsp;edit</a>
+                                    </c:if>
+                                </div>
+                                <span class="meta-label">Role</span>
+                                <code>${fn:escapeXml(empty roleResult.roleNodePath ? '(not found)' : roleResult.roleNodePath)}</code>
+                            </div>
+
+                            <div class="role-card-perms">
+                                <div class="perm-col" data-test-id="node-perms-col">
+                                    <div class="perm-col-title">Node permissions</div>
+                                    <c:choose>
+                                        <c:when test="${empty roleResult.nodePermissions}">
+                                            <span class="no-perm">(none)</span>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <ul class="perm-list">
+                                                <c:forEach var="perm" items="${roleResult.nodePermissions}">
+                                                    <li style="padding-left:${perm.indentPx}px">
+                                                        <c:choose>
+                                                            <c:when test="${perm.hierarchical}">
+                                                                <details class="perm-detail">
+                                                                    <summary><code class="${result.highlightedPermMap[perm.path] ? 'highlight-perm' : ''}">${fn:escapeXml(perm.localName)}</code></summary>
+                                                                    <span class="perm-full-path">${fn:escapeXml(perm.path)}</span>
+                                                                </details>
+                                                            </c:when>
+                                                            <c:otherwise>
+                                                                <code class="${result.highlightedPermMap[perm.path] ? 'highlight-perm' : ''}">${fn:escapeXml(perm.path)}</code>
+                                                            </c:otherwise>
+                                                        </c:choose>
+                                                    </li>
+                                                </c:forEach>
+                                            </ul>
+                                        </c:otherwise>
+                                    </c:choose>
+                                </div>
+
+                                <div class="perm-col" data-test-id="site-perms-col">
+                                    <div class="perm-col-title">Site permissions</div>
+                                    <c:choose>
+                                        <c:when test="${empty roleResult.sitePermissions}">
+                                            <span class="no-perm">(none)</span>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <c:forEach var="sitePermGroup" items="${roleResult.sitePermissions}">
+                                                <div class="perm-section">
+                                                    <div class="perm-section-label">
+                                                        <strong>${fn:escapeXml(sitePermGroup.name)}</strong>
+                                                        &mdash; checked on <code>${fn:escapeXml(sitePermGroup.targetPath)}</code>
+                                                    </div>
+                                                    <c:choose>
+                                                        <c:when test="${empty sitePermGroup.permissions}">
+                                                            <span class="no-perm">(none)</span>
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            <ul class="perm-list">
+                                                                <c:forEach var="perm" items="${sitePermGroup.permissions}">
+                                                                    <li style="padding-left:${perm.indentPx}px">
+                                                                        <c:choose>
+                                                                            <c:when test="${perm.hierarchical}">
+                                                                                <details class="perm-detail">
+                                                                                    <summary><code class="${result.highlightedPermMap[perm.path] ? 'highlight-perm' : ''}">${fn:escapeXml(perm.localName)}</code></summary>
+                                                                                    <span class="perm-full-path">${fn:escapeXml(perm.path)}</span>
+                                                                                </details>
+                                                                            </c:when>
+                                                                            <c:otherwise>
+                                                                                <code class="${result.highlightedPermMap[perm.path] ? 'highlight-perm' : ''}">${fn:escapeXml(perm.path)}</code>
+                                                                            </c:otherwise>
+                                                                        </c:choose>
+                                                                    </li>
+                                                                </c:forEach>
+                                                            </ul>
+                                                        </c:otherwise>
+                                                    </c:choose>
+                                                </div>
+                                            </c:forEach>
+                                        </c:otherwise>
+                                    </c:choose>
+                                </div>
+                            </div>
+                        </div>
+                    </c:forEach>
+                </div>
+            </c:otherwise>
+        </c:choose>
+    </c:if>
+</c:if>
+
+<%@ include file="commons/footer.jspf" %>
+</body>
+</html>

--- a/tests/cypress/e2e/userPermissions.spec.ts
+++ b/tests/cypress/e2e/userPermissions.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * End-to-end tests for the User Permissions Inspector tool (/modules/tools/userPermissions.jsp).
+ *
+ * Test scenarios:
+ *   - Form rendering (all fields visible, placeholder hints)
+ *   - No-permissions state (user has no roles on the node)
+ *   - Error state (node path does not exist)
+ *   - Direct user GRANT: role card, GRANT tag, node permissions, site permissions (external ACE)
+ *   - Group-based GRANT: user is a member of the granting group → group badge, site permissions,
+ *     j:sourceAce resolved to the actual content node
+ *   - Group principal lookup (g: prefix): inspect the group itself instead of a user
+ *   - Combined grants: both a direct user role and a group role appear simultaneously
+ *
+ * Test data created in `before()` and cleaned up in `after()`:
+ *   - User:  UP_TEST_USER  (member of UP_TEST_GROUP)
+ *   - Group: UP_TEST_GROUP (global — no site scope)
+ *   - Node:  /sites/systemsite/up-test-content  (jnt:contentFolder)
+ *
+ * Roles used: `editor` and `contributor` — both are built-in Jahia roles present in any
+ * standard Jahia installation. Both have `jnt:externalPermissions` nodes, so they produce
+ * external ACEs at site level when granted on a content node.
+ */
+import {
+    addNode,
+    addUserToGroup,
+    createGroup,
+    createUser,
+    deleteGroup,
+    deleteNode,
+    deleteUser,
+    grantRoles,
+    revokeRoles
+} from '@jahia/cypress';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const TOOL_URL = '/modules/tools/userPermissions.jsp';
+const SITE_KEY = 'systemsite';
+const UP_TEST_USER = 'up-test-user';
+const UP_TEST_PASSWORD = 'Password1!';
+const UP_TEST_GROUP = 'up-test-group';
+const CONTENT_NODE_NAME = 'up-test-content';
+const NODE_PATH = `/sites/${SITE_KEY}/${CONTENT_NODE_NAME}`;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Navigates to the tool, fills the form, and submits it.
+ *
+ * @param usernameOrGroup  Username or "g:groupname" to inspect.
+ * @param nodePath         JCR node path to inspect permissions on.
+ * @param userSite         Optional site key to select in the site dropdown.
+ */
+function submitForm(usernameOrGroup: string, nodePath: string, userSite?: string): void {
+    cy.visit(TOOL_URL);
+    cy.get('#username').clear();
+    cy.get('#username').type(usernameOrGroup);
+    if (userSite) {
+        cy.get('#userSite').select(userSite);
+    }
+
+    cy.get('#nodePath').clear();
+    cy.get('#nodePath').type(nodePath);
+    cy.get('input[type="submit"]').click();
+}
+
+/**
+ * Returns the role card element for the given role name.
+ * Relies on the `data-role-name` attribute added to each `.role-card`.
+ */
+function getRoleCard(roleName: string): Cypress.Chainable<JQuery<HTMLElement>> {
+    return cy.get(`.role-card[data-role-name="${roleName}"]`);
+}
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describe('User Permissions Inspector Tool (/modules/tools/userPermissions.jsp)', () => {
+    // ── Global test-data setup / teardown ────────────────────────────────────
+
+    before(() => {
+        // Cleanup first — guards against leftover state from a previously interrupted run.
+        // Revoke roles BEFORE deleting the node so Jahia's AclListener also removes the
+        // site-level external ACEs that live at /sites/systemsite/j:acl.
+        revokeRoles(NODE_PATH, ['editor'], UP_TEST_USER, 'USER');
+        revokeRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        revokeRoles(NODE_PATH, ['reader'], UP_TEST_USER, 'USER');
+        deleteNode(NODE_PATH);
+        deleteGroup(UP_TEST_GROUP, SITE_KEY);
+        deleteUser(UP_TEST_USER);
+
+        createUser(UP_TEST_USER, UP_TEST_PASSWORD);
+        // Site-scoped group: isMember(user, null, group, SITE_KEY) resolves reliably.
+        createGroup(UP_TEST_GROUP, false, SITE_KEY);
+        addUserToGroup(UP_TEST_USER, UP_TEST_GROUP, SITE_KEY);
+        addNode({
+            parentPathOrId: `/sites/${SITE_KEY}`,
+            name: CONTENT_NODE_NAME,
+            primaryNodeType: 'jnt:contentFolder'
+        });
+    });
+
+    after(() => {
+        deleteNode(NODE_PATH);
+        deleteGroup(UP_TEST_GROUP, SITE_KEY);
+        deleteUser(UP_TEST_USER);
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    // ── Form rendering ───────────────────────────────────────────────────────
+
+    describe('Form rendering', () => {
+        it('should display all form fields', () => {
+            cy.visit(TOOL_URL);
+            cy.get('#username').should('be.visible');
+            cy.get('#userSite').should('be.visible');
+            cy.get('#nodePath').should('be.visible');
+            cy.get('#workspace').should('be.visible');
+            cy.get('input[type="submit"]').should('be.visible');
+        });
+
+        it('should show the g: prefix hint in the username placeholder', () => {
+            cy.visit(TOOL_URL);
+            cy.get('#username').should('have.attr', 'placeholder').and('contain', 'g:');
+        });
+
+        it('should list available sites in the site dropdown', () => {
+            cy.visit(TOOL_URL);
+            cy.get('#userSite option').should('have.length.greaterThan', 1);
+            cy.get('#userSite option').contains(SITE_KEY).should('exist');
+        });
+    });
+
+    // ── Empty / error states ─────────────────────────────────────────────────
+
+    describe('Empty and error states', () => {
+        it('should not show test roles before they are explicitly granted', () => {
+            // G:users membership may produce inherited roles on site nodes, so we cannot
+            // assert "no results" in general. Instead we verify that our test-specific
+            // roles (editor / contributor) are absent before any grants are made.
+            submitForm(UP_TEST_USER, NODE_PATH);
+            cy.get('.role-card[data-role-name="editor"]').should('not.exist');
+            cy.get('.role-card[data-role-name="contributor"]').should('not.exist');
+        });
+
+        it('should show an error message for a non-existent node path', () => {
+            submitForm(UP_TEST_USER, '/this/path/does/not/exist/at/all');
+            cy.get('[data-test-id="error-msg"]')
+                .should('be.visible')
+                .and('contain', 'not found');
+        });
+    });
+
+    // ── Direct user GRANT ────────────────────────────────────────────────────
+
+    describe('Direct user role grant (editor → up-test-user)', () => {
+        before(() => {
+            grantRoles(NODE_PATH, ['editor'], UP_TEST_USER, 'USER');
+        });
+
+        after(() => {
+            revokeRoles(NODE_PATH, ['editor'], UP_TEST_USER, 'USER');
+        });
+
+        it('should display a role card with the correct role name', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            getRoleCard('editor').should('be.visible');
+        });
+
+        it('should show a GRANT tag on the role card', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            getRoleCard('editor').within(() => {
+                cy.get('.tag-grant').should('be.visible');
+            });
+        });
+
+        it('should display the user principal (not highlighted as group)', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            getRoleCard('editor').within(() => {
+                cy.get('[data-test-id="role-principal"]')
+                    .should('contain', UP_TEST_USER)
+                    .and('not.have.class', 'role-principal-group');
+            });
+        });
+
+        it('should list node-level permissions for the editor role', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            getRoleCard('editor').within(() => {
+                cy.get('[data-test-id="node-perms-col"] .perm-list li')
+                    .should('have.length.greaterThan', 0);
+            });
+        });
+
+        it('should show site-level (external ACE) permissions for the editor role', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            getRoleCard('editor').within(() => {
+                cy.get('[data-test-id="site-perms-col"] .perm-section')
+                    .should('have.length.greaterThan', 0);
+            });
+        });
+
+        it('should display the content node path where the role was granted', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            getRoleCard('editor').within(() => {
+                cy.get('.role-card-meta code').first().should('contain', NODE_PATH);
+            });
+        });
+    });
+
+    // ── Group-based GRANT ────────────────────────────────────────────────────
+
+    // Use `editor` (same as direct-user tests) — it is a guaranteed built-in role with
+    // external permissions. `contributor` may not exist or may have no permissions defined.
+
+    describe('Group-based role grant (editor → up-test-group, user is member)', () => {
+        before(() => {
+            grantRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        });
+
+        after(() => {
+            revokeRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        });
+
+        it('should display the role card when inspecting a user who is a member of the granting group', () => {
+            // Pass userSite so matchesPrincipal resolves site-scoped group membership correctly.
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            // The group-granted card has the group principal badge; selector scopes by principal.
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .contains('[data-test-id="role-principal"]', `g:${UP_TEST_GROUP}`)
+                .should('exist');
+        });
+
+        it('should show a GRANT tag on the group-based role card', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .filter(':has([data-test-id="role-principal"].role-principal-group)')
+                .find('.tag-grant')
+                .should('be.visible');
+        });
+
+        it('should highlight the principal badge in blue (group style) for a group-based grant', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            // At least one editor card must carry the group-principal class and the group name.
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .find('[data-test-id="role-principal"].role-principal-group')
+                .should('exist')
+                .and('contain', `g:${UP_TEST_GROUP}`);
+        });
+
+        it('should show site-level permissions for the group-granted role', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .filter(':has([data-test-id="role-principal"].role-principal-group)')
+                .find('[data-test-id="site-perms-col"] .perm-section')
+                .should('have.length.greaterThan', 0);
+        });
+
+        it('should resolve the j:sourceAce to the actual content node and show it in the card meta', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            // The content grant path must point to the node where the role was granted,
+            // not to the site node where the external ACE lives.
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .filter(':has([data-test-id="role-principal"].role-principal-group)')
+                .find('.role-card-meta code')
+                .first()
+                .should('contain', NODE_PATH);
+        });
+
+        it('should display the jContent edit link for the grant node', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .filter(':has([data-test-id="role-principal"].role-principal-group)')
+                .find('.role-card-meta .edit-link')
+                .should('be.visible');
+        });
+    });
+
+    // ── Group principal lookup (g: prefix) ───────────────────────────────────
+
+    describe('Group principal lookup using g: prefix', () => {
+        before(() => {
+            grantRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        });
+
+        after(() => {
+            revokeRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        });
+
+        it('should display the role card when inspecting the group directly', () => {
+            submitForm(`g:${UP_TEST_GROUP}`, NODE_PATH);
+            getRoleCard('editor').should('be.visible');
+        });
+
+        it('should show the group as the matched principal', () => {
+            submitForm(`g:${UP_TEST_GROUP}`, NODE_PATH);
+            getRoleCard('editor').within(() => {
+                cy.get('[data-test-id="role-principal"]')
+                    .should('contain', `g:${UP_TEST_GROUP}`);
+            });
+        });
+
+        it('should NOT show roles that were granted only to the individual user, not the group', () => {
+            // Grant a second role directly to the user only, then inspect the group — it must not appear.
+            grantRoles(NODE_PATH, ['reader'], UP_TEST_USER, 'USER');
+            submitForm(`g:${UP_TEST_GROUP}`, NODE_PATH);
+            cy.get('.role-card[data-role-name="reader"]').should('not.exist');
+            revokeRoles(NODE_PATH, ['reader'], UP_TEST_USER, 'USER');
+        });
+    });
+
+    // ── Combined grants ──────────────────────────────────────────────────────
+
+    describe('Combined grants: editor granted to user directly AND to the group', () => {
+        before(() => {
+            grantRoles(NODE_PATH, ['editor'], UP_TEST_USER, 'USER');
+            grantRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        });
+
+        after(() => {
+            revokeRoles(NODE_PATH, ['editor'], UP_TEST_USER, 'USER');
+            revokeRoles(NODE_PATH, ['editor'], UP_TEST_GROUP, 'GROUP');
+        });
+
+        it('should show two separate editor role cards — one per principal', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            // Two editor cards: one for the direct user grant, one for the group grant.
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .should('have.length', 2);
+        });
+
+        it('should show one card with user principal and one with group principal', () => {
+            submitForm(UP_TEST_USER, NODE_PATH, SITE_KEY);
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .find('[data-test-id="role-principal"]:not(.role-principal-group)')
+                .should('exist');
+            cy.get('[data-test-id="role-card"][data-role-name="editor"]')
+                .find('[data-test-id="role-principal"].role-principal-group')
+                .should('exist');
+        });
+    });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "@jahia/cypress": "^4.5.0",
+    "@jahia/cypress": "^8.1.0",
     "@jahia/eslint-config": "^1.1.0",
     "@jahia/jahia-reporter": "^1.1.16",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
@@ -36,5 +36,6 @@
     "node-ssh": "^12.0.4",
     "prettier": "^2.4.0",
     "typescript": "^4.4.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -167,6 +167,11 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@faker-js/faker@^10.3.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-10.4.0.tgz#2dc84d1bc32a2eef3c4658985ca7692a0c5c51b3"
+  integrity sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==
+
 "@graphql-typed-document-node/core@^3.1.1":
   version "3.2.0"
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
@@ -191,24 +196,14 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@isaacs/cliui@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
-  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
-  dependencies:
-    string-width "^5.1.2"
-    string-width-cjs "npm:string-width@^4.2.0"
-    strip-ansi "^7.0.1"
-    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
-    wrap-ansi "^8.1.0"
-    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
-
-"@jahia/cypress@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/@jahia/cypress/-/cypress-4.5.0.tgz"
-  integrity sha512-2DKhUP/68AOQ+4dHUBdJPbVbMD8JgUaHTcBpS2ZBzC4oLfQAckFJPuX/itr4IusuziX2M6CuOjmR2rsHYGWU6g==
+"@jahia/cypress@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-8.1.0.tgz#8ee056ac93b8194029b80c1f5747601c3be735c5"
+  integrity sha512-sf2WEA8WFIQaU17MPWCjCbW3AH6pv5FRa/2A554fiE4DsmEw49rNJrJHEPYgN6T5Ls6IzQ1hBSoHE0DQyBS/QQ==
   dependencies:
     "@apollo/client" "^3.4.9"
+    "@faker-js/faker" "^10.3.0"
+    compare-versions "^6.1.1"
     cypress-real-events "^1.11.0"
     graphql "^15.5.0"
     graphql-tag "^2.11.0"
@@ -299,7 +294,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -323,18 +318,6 @@
     "@oclif/parser" "^3.8.17"
     debug "^4.1.1"
     semver "^7.5.4"
-
-"@oclif/config@^1", "@oclif/config@^1.18.2":
-  version "1.18.17"
-  resolved "https://registry.npmjs.org/@oclif/config/-/config-1.18.17.tgz"
-  integrity sha512-k77qyeUvjU8qAJ3XK3fr/QVAqsZO8QOBuESnfeM5HHtPNLSyfVcwiMM2zveSW5xRdLSG3MfV8QnLVkuyCL2ENg==
-  dependencies:
-    "@oclif/errors" "^1.3.6"
-    "@oclif/parser" "^3.8.17"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-wsl "^2.1.1"
-    tslib "^2.6.1"
 
 "@oclif/config@1.18.16":
   version "1.18.16"
@@ -360,27 +343,17 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
-"@oclif/errors@^1.3.3":
-  version "1.3.6"
-  resolved "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.6.tgz"
-  integrity sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==
+"@oclif/config@^1", "@oclif/config@^1.18.2":
+  version "1.18.17"
+  resolved "https://registry.npmjs.org/@oclif/config/-/config-1.18.17.tgz"
+  integrity sha512-k77qyeUvjU8qAJ3XK3fr/QVAqsZO8QOBuESnfeM5HHtPNLSyfVcwiMM2zveSW5xRdLSG3MfV8QnLVkuyCL2ENg==
   dependencies:
-    clean-stack "^3.0.0"
-    fs-extra "^8.1"
-    indent-string "^4.0.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
-
-"@oclif/errors@^1.3.5", "@oclif/errors@^1.3.6", "@oclif/errors@1.3.6":
-  version "1.3.6"
-  resolved "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.6.tgz"
-  integrity sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==
-  dependencies:
-    clean-stack "^3.0.0"
-    fs-extra "^8.1"
-    indent-string "^4.0.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
+    "@oclif/errors" "^1.3.6"
+    "@oclif/parser" "^3.8.17"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-wsl "^2.1.1"
+    tslib "^2.6.1"
 
 "@oclif/errors@1.3.5":
   version "1.3.5"
@@ -391,6 +364,17 @@
     fs-extra "^8.1"
     indent-string "^4.0.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+"@oclif/errors@1.3.6", "@oclif/errors@^1.3.3", "@oclif/errors@^1.3.5", "@oclif/errors@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.6.tgz"
+  integrity sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==
+  dependencies:
+    clean-stack "^3.0.0"
+    fs-extra "^8.1"
+    indent-string "^4.0.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 "@oclif/help@^1.0.1":
@@ -452,11 +436,6 @@
   dependencies:
     browser-or-node "^2.0.0"
     cross-fetch "^3.0.6"
-
-"@pkgjs/parseargs@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
-  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@slack/logger@^3.0.0":
   version "3.0.0"
@@ -528,12 +507,7 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^10":
-  version "10.17.60"
-  resolved "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
-
-"@types/node@^10.0.3":
+"@types/node@^10", "@types/node@^10.0.3":
   version "10.17.60"
   resolved "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
@@ -587,7 +561,7 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^5.0.0 || ^6.0.0 || ^7.0.0", "@typescript-eslint/eslint-plugin@^5.48.1":
+"@typescript-eslint/eslint-plugin@^5.48.1":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz"
   integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
@@ -613,7 +587,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.48.1":
+"@typescript-eslint/parser@^5.48.1":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz"
   integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
@@ -672,7 +646,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@5.62.0":
+"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -746,15 +720,15 @@ acorn-jsx@^5.2.0, acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.9.0:
-  version "8.12.1"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz"
-  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
-
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.9.0:
+  version "8.12.1"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
 agent-base@6:
   version "6.0.2"
@@ -781,7 +755,7 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-colors@^4.1.1, ansi-colors@^4.1.3:
+ansi-colors@^4.1.1:
   version "4.1.3"
   resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
@@ -803,19 +777,7 @@ ansi-regex@^5.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz"
-  integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
-
-ansi-styles@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
-
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -829,23 +791,10 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz"
-  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
-
 ansicolors@~0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz"
   integrity sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==
-
-anymatch@~3.1.2:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
-  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
 
 arch@^2.2.0:
   version "2.2.0"
@@ -968,7 +917,7 @@ asn1@^0.2.6, asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-assert-plus@^1.0.0, assert-plus@1.0.0:
+assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
@@ -1065,11 +1014,6 @@ bignumber.js@^9.0.0:
   resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
-binary-extensions@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
-  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
-
 blob-util@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz"
@@ -1088,34 +1032,22 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
 
-browser-or-node@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz"
-  integrity sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==
-
 browser-or-node@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.0.0.tgz"
   integrity sha512-3Lrks/Okgof+/cRguUNG+qRXSeq79SO3hY4QrXJayJofwJwHiGC0qi99uDjsfTwULUFSr1OGVsBkdIkygKjTUA==
 
-browser-stdout@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
-  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+browser-or-node@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz"
+  integrity sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -1171,11 +1103,6 @@ camelcase@^5.0.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
-  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
-
 cardinal@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz"
@@ -1189,16 +1116,7 @@ caseless@^0.12.0, caseless@~0.12.0:
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
-chalk@^2.1.0:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chalk@^2.4.2:
+chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1229,21 +1147,6 @@ check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz"
   integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
-
-chokidar@^3.5.3:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz"
-  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 ci-info@^3.2.0:
   version "3.9.0"
@@ -1362,15 +1265,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorette@^2.0.16:
   version "2.0.20"
@@ -1384,20 +1287,25 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz"
-  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
-
 commander@2.19.0:
   version "2.19.0"
   resolved "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
 common-tags@^1.8.0:
   version "1.8.2"
   resolved "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
+
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1414,15 +1322,15 @@ concat-stream@^1.6.0, concat-stream@^1.6.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cpu-features@~0.0.9:
   version "0.0.10"
@@ -1493,7 +1401,7 @@ cypress-wait-until@^1.7.2:
   resolved "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz"
   integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
 
-"cypress@^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x", cypress@>=10.0.0, cypress@13.9.0:
+cypress@13.9.0:
   version "13.9.0"
   resolved "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz"
   integrity sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==
@@ -1598,6 +1506,13 @@ dayjs@^1.10.4:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
+debug@4, debug@^4.0.1, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.1.0:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
@@ -1605,22 +1520,10 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@4:
-  version "4.3.6"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
-  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
-  dependencies:
-    ms "2.1.2"
-
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
-
-decamelize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz"
-  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
@@ -1655,7 +1558,7 @@ diff@^4.0.1:
   resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-diff@^5.0.0, diff@^5.2.0:
+diff@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz"
   integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
@@ -1686,11 +1589,6 @@ dom-walk@^0.1.0:
   resolved "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
 
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
-  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
@@ -1699,7 +1597,7 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ecdsa-sig-formatter@^1.0.11, ecdsa-sig-formatter@1.0.11:
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
   resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
@@ -1716,11 +1614,6 @@ emoji-regex@^8.0.0:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emoji-regex@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
-  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
-
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz"
@@ -1728,7 +1621,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.6, "enquirer@>= 2.3.0 < 3":
+enquirer@^2.3.6:
   version "2.4.1"
   resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz"
   integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
@@ -1862,20 +1755,15 @@ escape-html@^1.0.3:
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
-escape-string-regexp@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-escape-string-regexp@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
-  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-config-prettier@^8.3.0:
   version "8.10.0"
@@ -1926,7 +1814,7 @@ eslint-plugin-json@^3.1.0:
     lodash "^4.17.21"
     vscode-json-languageservice "^4.1.6"
 
-eslint-plugin-react-hooks@^2.2.0, eslint-plugin-react-hooks@>=1.6.1:
+eslint-plugin-react-hooks@^2.2.0:
   version "2.5.1"
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz"
   integrity sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==
@@ -1936,7 +1824,7 @@ eslint-plugin-react-hooks@^4.6.0:
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz"
   integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
-eslint-plugin-react@^7.16.0, eslint-plugin-react@^7.32.0, eslint-plugin-react@>=7.14.2:
+eslint-plugin-react@^7.16.0, eslint-plugin-react@^7.32.0:
   version "7.35.0"
   resolved "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz"
   integrity sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==
@@ -1995,22 +1883,55 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint-visitor-keys@^3.4.1:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
-  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+eslint@^6.6.0:
+  version "6.8.0"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.3"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
-eslint-visitor-keys@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
-  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
-
-eslint@*, "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0", eslint@^8.31.0, eslint@>=3.0.0, eslint@>=7, eslint@>=7.0.0:
+eslint@^8.31.0:
   version "8.57.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz"
   integrity sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==
@@ -2053,49 +1974,6 @@ eslint@*, "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^
     optionator "^0.9.3"
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
-
-"eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0", eslint@^6.6.0, "eslint@>= 4.12.1", eslint@>=5, eslint@>=6, eslint@>=6.4.0:
-  version "6.8.0"
-  resolved "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz"
-  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    ajv "^6.10.0"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^1.4.3"
-    eslint-visitor-keys "^1.1.0"
-    espree "^6.1.2"
-    esquery "^1.0.1"
-    esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    inquirer "^7.0.0"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.14"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    optionator "^0.8.3"
-    progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^6.1.2"
-    strip-ansi "^5.2.0"
-    strip-json-comments "^3.0.1"
-    table "^5.2.3"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
 
 espree@^6.1.2:
   version "6.2.1"
@@ -2221,15 +2099,15 @@ extract-zip@2.0.1:
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
 
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2338,11 +2216,6 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flat@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz"
-  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
-
 flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz"
@@ -2364,14 +2237,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-foreground-child@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz"
-  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
-  dependencies:
-    cross-spawn "^7.0.0"
-    signal-exit "^4.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2405,16 +2270,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-fs-extra@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
-fs-extra@^10.1.0:
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -2455,11 +2311,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 fsu@^1.1.1:
   version "1.1.1"
@@ -2561,7 +2412,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.0.0, glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2574,18 +2425,6 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob@^10.4.5:
-  version "10.4.5"
-  resolved "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
-  dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^3.1.2"
-    minimatch "^9.0.4"
-    minipass "^7.1.2"
-    package-json-from-dist "^1.0.0"
-    path-scurry "^1.11.1"
 
 glob@^7.1.3, glob@^7.1.6:
   version "7.2.3"
@@ -2708,7 +2547,7 @@ graphql-tag@^2.11.0, graphql-tag@^2.12.6:
   dependencies:
     tslib "^2.1.0"
 
-"graphql@^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "graphql@^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "graphql@^15.0.0 || ^16.0.0", graphql@^15.5.0:
+graphql@^15.5.0:
   version "15.9.0"
   resolved "https://registry.npmjs.org/graphql/-/graphql-15.9.0.tgz"
   integrity sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==
@@ -2767,11 +2606,6 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
-
-he@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -2872,7 +2706,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.3, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2931,13 +2765,6 @@ is-bigint@^1.0.1:
   integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
   dependencies:
     has-bigints "^1.0.1"
-
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
 
 is-boolean-object@^1.1.0:
   version "1.1.2"
@@ -3024,7 +2851,7 @@ is-generator-function@^1.0.10:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3065,11 +2892,6 @@ is-path-inside@^3.0.2, is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
-
-is-plain-obj@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
-  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -3189,15 +3011,6 @@ iterator.prototype@^1.1.2:
     has-symbols "^1.0.3"
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
-
-jackspeak@^3.1.2:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz"
-  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-  optionalDependencies:
-    "@pkgjs/parseargs" "^0.11.0"
 
 js-base64@^3.6.0:
   version "3.7.7"
@@ -3425,7 +3238,7 @@ lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@^4.0.0, log-symbols@^4.1.0:
+log-symbols@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -3449,11 +3262,6 @@ loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-lru-cache@^10.2.0:
-  version "10.4.3"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
-  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3532,29 +3340,10 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.1.6:
-  version "5.1.6"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^9.0.4:
-  version "9.0.5"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 mkdirp@^0.5.1:
   version "0.5.6"
@@ -3578,32 +3367,6 @@ mocha-junit-reporter@^2.2.0:
     mkdirp "^3.0.0"
     strip-ansi "^6.0.1"
     xml "^1.0.1"
-
-mocha@>=2.2.5, mocha@>=3.1.2, mocha@>=7:
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz"
-  integrity sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==
-  dependencies:
-    ansi-colors "^4.1.3"
-    browser-stdout "^1.3.1"
-    chokidar "^3.5.3"
-    debug "^4.3.5"
-    diff "^5.2.0"
-    escape-string-regexp "^4.0.0"
-    find-up "^5.0.0"
-    glob "^10.4.5"
-    he "^1.2.0"
-    js-yaml "^4.1.0"
-    log-symbols "^4.1.0"
-    minimatch "^5.1.6"
-    ms "^2.1.3"
-    serialize-javascript "^6.0.2"
-    strip-json-comments "^3.1.1"
-    supports-color "^8.1.1"
-    workerpool "^6.5.1"
-    yargs "^17.7.2"
-    yargs-parser "^21.1.1"
-    yargs-unparser "^2.0.0"
 
 mochawesome-merge@^4.2.0:
   version "4.3.0"
@@ -3648,20 +3411,15 @@ mochawesome@^7.0.1:
     strip-ansi "^6.0.1"
     uuid "^8.3.2"
 
-ms@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -3716,11 +3474,6 @@ node-ssh@^12.0.4:
     sb-scandir "^3.1.0"
     shell-escape "^0.2.0"
     ssh2 "^1.5.0"
-
-normalize-path@^3.0.0, normalize-path@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
-  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 npm-run-path@^4.0.0:
   version "4.0.1"
@@ -3918,11 +3671,6 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-package-json-from-dist@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz"
-  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -3973,14 +3721,6 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
-  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
-  dependencies:
-    lru-cache "^10.2.0"
-    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
-
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
@@ -4001,7 +3741,7 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -4072,15 +3812,15 @@ prop-types@^15.7.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
 proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"
@@ -4100,19 +3840,19 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@^6.4.0:
-  version "6.13.0"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz"
-  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
-  dependencies:
-    side-channel "^1.0.6"
-
 qs@6.10.4:
   version "6.10.4"
   resolved "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz"
   integrity sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==
   dependencies:
     side-channel "^1.0.4"
+
+qs@^6.4.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz"
+  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+  dependencies:
+    side-channel "^1.0.6"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -4123,13 +3863,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -4148,13 +3881,6 @@ readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
 
 redeyed@~2.1.0:
   version "2.1.1"
@@ -4269,17 +3995,17 @@ rfdc@^1.3.0:
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -4319,17 +4045,12 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -4343,7 +4064,7 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
-safer-buffer@^2.0.2, safer-buffer@^2.1.0, "safer-buffer@>= 2.1.2 < 3", safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4370,17 +4091,7 @@ semver@^5.5.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@^6.0.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.1.2:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.0.0, semver@^6.1.2, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -4389,13 +4100,6 @@ semver@^7.3.2, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   version "7.6.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -4467,11 +4171,6 @@ signal-exit@^3.0.2:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-signal-exit@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
-  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -4549,22 +4248,6 @@ sshpk@^1.14.1:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz"
@@ -4582,15 +4265,6 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string-width@^5.0.1, string-width@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
-  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
-  dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.11:
   version "4.0.11"
@@ -4646,21 +4320,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
-    ansi-regex "^5.0.1"
+    safe-buffer "~5.1.0"
 
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
-
-strip-ansi@^5.2.0:
+strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -4673,13 +4340,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-ansi@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz"
-  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
-  dependencies:
-    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4710,14 +4370,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.1.0:
-  version "8.1.1"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^8.1.1:
+supports-color@^8.1.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -4883,17 +4536,7 @@ ts-sync-request@^1.4.1:
   dependencies:
     sync-request "^6.0.0"
 
-tslib@^1:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^1.9.0:
+tslib@^1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -5005,7 +4648,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.4.2, typescript@^4.4.4, typescript@>=2.7, "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta":
+typescript@^4.4.2, typescript@^4.4.4:
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
@@ -5214,20 +4857,6 @@ word-wrap@^1.2.5, word-wrap@~1.2.3:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-workerpool@^6.5.1:
-  version "6.5.1"
-  resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz"
-  integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
-
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
@@ -5245,15 +4874,6 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -5307,16 +4927,6 @@ yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs-unparser@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz"
-  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
-  dependencies:
-    camelcase "^6.0.0"
-    decamelize "^4.0.0"
-    flat "^5.0.2"
-    is-plain-obj "^2.1.0"
-
 yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz"
@@ -5335,19 +4945,6 @@ yargs@^15.3.1:
     yargs-parser "^18.1.2"
 
 yargs@^17.2.1:
-  version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
-yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
### Description
This tool helps to understand where a given permission is coming from when checked on a given node.

<img width="1228" height="933" alt="Screenshot 2026-05-17 at 18 00 55" src="https://github.com/user-attachments/assets/ac9b36cd-3ee4-48aa-91b3-c89ace45e7c1" />

### How it works
#### Input:
**principal**: username or group, group is identified by the **g:** prefix
**site**: global or from a given site
**node path**: path of the node to check
**workspace**: live/default
**permission**: name of the permission to check, leave empty to get all permissions for the given principal/node couple.
#### Output:
if a permission is provided, the result of a check result of the permission against the node for the provided user.
If the permission is granted, the node / role that bring the permission to the user
If the permission is granted, and the role not found, the tool needs to be improved to catch where the permission is coming from.
A way is to identify the role/node is to put a breakpoint in this method:
https://github.com/Jahia/jahia-private/blob/4a2f6dffe558040058db84b427ae6cef4f2ada0e/core/src/main/java/org/jahia/utils/security/AccessManagerUtils.java#L428
in the `return true` statements. 

The tool display also all permissions granted/deny to the provided node and user/group.

#### Tests
- [x] I've provided Unit and/or Integration Tests
