### PR TITLE
chore: removed the preview feature in the ehcache table

### DIFF
--- a/.chachalog/dvlDbqcH.md
+++ b/.chachalog/dvlDbqcH.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+tools: patch
+---
+
+Removed the preview feature in the ehcache table (#315)

--- a/impl/src/main/resources/ehcache/ehcache_cj.jsp
+++ b/impl/src/main/resources/ehcache/ehcache_cj.jsp
@@ -65,7 +65,6 @@
         <li><a href="?flush=true&toolAccessToken=${toolAccessToken}"
                onclick="return confirm('This will flush the content of the cache. Would you like to continue?')"
                title="flush the content of the module output cache"><span class="material-symbols-outlined">recycling</span>Flush</a></li>
-        <li><a href="?viewContent=${param.viewContent ? 'false' : 'true'}&toolAccessToken=${toolAccessToken}"><span class="material-symbols-outlined">preview</span>${param.viewContent ? 'Hide content preview' : 'Preview content'}</a></li>
     </c:set>
     <%@ include file="../commons/header.jspf" %>
 

--- a/impl/src/main/resources/ehcache/ehcache_cj.jsp
+++ b/impl/src/main/resources/ehcache/ehcache_cj.jsp
@@ -108,25 +108,20 @@
                         cacheSize += content != null ? content.length() : 0;
                     %>
                     <td>
-                        <c:if test="${param.viewContent}" var="viewContent">
-                            <%= content %>
-                        </c:if>
-                        <c:if test="${not viewContent}">
-                            <div style="text-align: center;">
-                                <c:url var="detailsUrl" value="ehcache_cj.jsp">
-                                    <c:param name="key" value="${key}"/>
-                                    <c:param name="toolAccessToken" value="${toolAccessToken}"/>
-                                </c:url>
-                                <c:url var="flushUrl" value="ehcache_cj.jsp">
-                                    <c:param name="flushkey" value="${key}"/>
-                                    <c:param name="toolAccessToken" value="${toolAccessToken}"/>
-                                </c:url>
-                                <a href="${detailsUrl}" target="_blank">view</a>
-                                <a href="${flushUrl}">flush</a>
-                                <br/>[<%= FileUtils.byteCountToDisplaySize(content.length()).replace(" ", "&nbsp;") %>
-                                ]<br/>
-                            </div>
-                        </c:if>
+                        <div style="text-align: center;">
+                            <c:url var="detailsUrl" value="ehcache_cj.jsp">
+                                <c:param name="key" value="${key}"/>
+                                <c:param name="toolAccessToken" value="${toolAccessToken}"/>
+                            </c:url>
+                            <c:url var="flushUrl" value="ehcache_cj.jsp">
+                                <c:param name="flushkey" value="${key}"/>
+                                <c:param name="toolAccessToken" value="${toolAccessToken}"/>
+                            </c:url>
+                            <a href="${detailsUrl}" target="_blank">view</a>
+                            <a href="${flushUrl}">flush</a>
+                            <br/>[<%= FileUtils.byteCountToDisplaySize(content.length()).replace(" ", "&nbsp;") %>
+                            ]<br/>
+                        </div>
                     </td>
                     <%} else { %>
                     <td>empty</td>


### PR DESCRIPTION
This pull request simplifies the cache management JSP page by removing the content preview feature. The main change is the removal of the ability to toggle and display the cache content directly from the UI.

**UI Simplification:**

* Removed the "Preview content" toggle link from the navigation menu, so users can no longer show or hide cache content previews from the UI.
* Removed the conditional logic and UI elements that displayed the cache content when the preview was enabled. Now, only the cache size and related information are shown, without exposing the actual content. [[1]](diffhunk://#diff-6acfd9a8dd083b20acd3b8316499819907efd70fa86283c04fcdd4aba0f8e57bL112-L115) [[2]](diffhunk://#diff-6acfd9a8dd083b20acd3b8316499819907efd70fa86283c04fcdd4aba0f8e57bL130)