### PR TITLE
fix: escape node names in the JCR query results view

### DIFF
--- a/.chachalog/lUjiEViP.md
+++ b/.chachalog/lUjiEViP.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+tools: minor
+---
+
+HTML-escape node names rendered in the JCR query results view, including inside the delete-action handler, matching the JCR browser view.

--- a/impl/src/main/resources/jcrQuery.jsp
+++ b/impl/src/main/resources/jcrQuery.jsp
@@ -361,8 +361,8 @@
                             <li>
                                 <a title="Open in JCR Browser"
                                    href="<c:url value='jcrBrowser.jsp?uuid=${node.identifier}&workspace=${workspace}&showProperties=true&showJCRNodes=true&toolAccessToken=${toolAccessToken}'/>"
-                                   target="_blank"><strong>${node.name}</strong></a>
-                                <strong>${node.name}</strong>
+                                   target="_blank"><strong>${fn:escapeXml(node.name)}</strong></a>
+                                <strong>${fn:escapeXml(node.name)}</strong>
                                 <c:forEach items="${node.mixinNodeTypes}" var="mixin">
                                     ${mixin.name}
                                 </c:forEach>
@@ -382,7 +382,7 @@
                                     %>
                                     <a title="Open in JCR Browser"
                                        href="<c:url value='jcrBrowser.jsp?uuid=${node.identifier}&workspace=${workspace}&showProperties=true&showJCRNodes=true&toolAccessToken=${toolAccessToken}'/>"
-                                       target="_blank"><strong>${node.name}</strong></a>
+                                       target="_blank"><strong>${fn:escapeXml(node.name)}</strong></a>
                                     <c:forEach items="${node.mixinNodeTypes}" var="mixin">
                                         ${mixin.name}
                                     </c:forEach>
@@ -409,7 +409,7 @@
                                    target="_blank"><img src="<c:url value='/icons/fileManager.png'/>" width="16"
                                                         height="16" alt="open" title="Open in Repository Explorer"></a>
                                 <c:if test="${showActions}">
-                                    &nbsp;<a href="#delete" onclick='var nodeName="${node.name}"; if (!confirm("You are about to delete the node \"" + nodeName + "\" with all child nodes. Continue?")) return false; go("action", "delete", "target", "${node.identifier}"); return false;' title="Delete"><img src="<c:url
+                                    &nbsp;<a href="#delete" onclick='var nodeName="${fn:escapeXml(functions:escapeJavaScript(node.name))}"; if (!confirm("You are about to delete the node \"" + nodeName + "\" with all child nodes. Continue?")) return false; go("action", "delete", "target", "${node.identifier}"); return false;' title="Delete"><img src="<c:url
                                         value='/icons/delete.png'/>" height="16" width="16" title="Delete" border="0"/></a>
                                 </c:if>
                                 <br/>
@@ -453,7 +453,7 @@
                                        target="_blank"><img src="<c:url value='/icons/fileManager.png'/>" width="16"
                                                             height="16" alt="open" title="Open in Repository Explorer"></a>
                                     <c:if test="${showActions}">
-                                        &nbsp;<a href="#delete" onclick='var nodeName="${node.name}"; if (!confirm("You are about to delete the node \"" + nodeName + "\" with all child nodes. Continue?")) return false; go("action", "delete", "target", "${node.identifier}"); return false;' title="Delete"><img src="<c:url
+                                        &nbsp;<a href="#delete" onclick='var nodeName="${fn:escapeXml(functions:escapeJavaScript(node.name))}"; if (!confirm("You are about to delete the node \"" + nodeName + "\" with all child nodes. Continue?")) return false; go("action", "delete", "target", "${node.identifier}"); return false;' title="Delete"><img src="<c:url
                                             value='/icons/delete.png'/>" height="16" width="16" title="Delete" border="0"/></a>
                                     </c:if>
                                     <br/>


### PR DESCRIPTION
The JCR query results view rendered result node names verbatim, both as displayed text and inside the delete-action `onclick` handler. The sibling JCR browser view already escapes node names; this brings the query view in line (HTML-escape for text, JS-string + HTML-attribute escaping inside the handler).