### PR TITLE
fix: escape the node path in the JCR query results Repository Explorer link

### DIFF
--- a/.chachalog/OHuPOYnw.md
+++ b/.chachalog/OHuPOYnw.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+tools: patch
+---
+
+URL-encode and HTML-escape the node path rendered in the "Open in Repository Explorer" link of the JCR query results view, completing the escaping of that view.

--- a/impl/src/main/resources/jcrQuery.jsp
+++ b/impl/src/main/resources/jcrQuery.jsp
@@ -407,7 +407,7 @@
                                    target="_blank"><strong>${fn:escapeXml(not empty node.displayableName ? node.name : '<root>')}</strong></a>
                                 (${fn:escapeXml(node.nodeTypes)})
                                 <a title="Open in Repository Explorer"
-                                   href="<c:url value='/engines/manager.jsp?selectedPaths=${node.path}&workspace=${workspace}'/>"
+                                   href="<c:url value='/engines/manager.jsp?selectedPaths=${fn:escapeXml(functions:escapePath(node.path))}&workspace=${workspace}'/>"
                                    target="_blank"><img src="<c:url value='/icons/fileManager.png'/>" width="16"
                                                         height="16" alt="open" title="Open in Repository Explorer"></a>
                                 <c:if test="${showActions}">
@@ -451,7 +451,7 @@
                                        href="<c:url value='jcrBrowser.jsp?uuid=${node.identifier}&workspace=${workspace}&showProperties=true&toolAccessToken=${toolAccessToken}'/>"
                                        target="_blank"><strong>${fn:escapeXml(not empty node.displayableName ? node.name : '<root>')}</strong></a> (${fn:escapeXml(node.nodeTypes)})
                                     <a title="Open in Repository Explorer"
-                                       href="<c:url value='/engines/manager.jsp?selectedPaths=${node.path}&workspace=${workspace}&toolAccessToken=${toolAccessToken}'/>"
+                                       href="<c:url value='/engines/manager.jsp?selectedPaths=${fn:escapeXml(functions:escapePath(node.path))}&workspace=${workspace}&toolAccessToken=${toolAccessToken}'/>"
                                        target="_blank"><img src="<c:url value='/icons/fileManager.png'/>" width="16"
                                                             height="16" alt="open" title="Open in Repository Explorer"></a>
                                     <c:if test="${showActions}">


### PR DESCRIPTION
Hardening of the JCR query results view: the node path rendered into the "Open in Repository Explorer" link is now URL-encoded and HTML-escaped, consistent with how the same value is already rendered elsewhere on the page.

```jsp
selectedPaths=${fn:escapeXml(functions:escapePath(node.path))}
```

- `functions:escapePath` (`org.jahia.utils.WebUtils.escapePath`) URL-encodes each path segment and leaves the separators, so an ordinary path renders byte-unchanged and the link keeps working.
- `fn:escapeXml` covers the surrounding attribute — the same inner-value / outer-attribute pairing already used for `node.name` in this view.

No new taglib dependency: `functions` is already imported in this JSP. No API or behaviour change, hence the `patch` bump.

Follow-up to #326, which covered `node.name` in these same two blocks.

Internal tracking: SECURITY / SEC-266.

### Testing

`functions:escapePath` was exercised directly against the deployed `jahia-taglib` 8.2.4.0-SNAPSHOT to confirm ordinary paths are unchanged and reserved characters are encoded.

Note for the reviewer: nothing in CI compiles this JSP's body (there is no `jspc` step, and the integration suite only renders `index.jsp` and `jcrBrowser.jsp`), so please exercise the JCR query page on a running instance before merging. A regression test is tracked internally.