### PR TITLE
feat: enforce authorization in jsp (backport to 4_x / Jahia 8.1.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,11 +109,33 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>jsp-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Embed dependencies -->
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.utils</artifactId>
             <version>${felix.utils.version}</version>
+        </dependency>
+
+        <!-- test-only dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- mockito-inline provides the inline mock maker required by Mockito.mockStatic(). Pinned to the 4.x line:
+             this branch is built and released with JDK 8 (see .github/workflows), which Mockito 5 no longer supports. -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jahia/modules/tools/JspPrecompileServlet.java
+++ b/src/main/java/org/jahia/modules/tools/JspPrecompileServlet.java
@@ -17,6 +17,7 @@ package org.jahia.modules.tools;
 
 import org.jahia.bin.listeners.JahiaContextLoaderListener;
 import org.jahia.modules.tools.csrf.ToolsAccessTokenFilter;
+import org.jahia.modules.tools.security.ToolsAccessGuard;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.osgi.FrameworkService;
 import org.jahia.utils.NoOutputResponseWrapper;
@@ -66,6 +67,10 @@ public class JspPrecompileServlet extends HttpServlet {
      */
     private void doWork(HttpServletRequest aRequest,
             HttpServletResponse aResponse) throws ServletException, IOException {
+        if (!ToolsAccessGuard.isGranted()) {
+            aResponse.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
         aRequest.getSession(true);
 
         String jspName = aRequest.getParameter(JSP_NAME_PARAM);

--- a/src/main/java/org/jahia/modules/tools/security/ToolsAccessGuard.java
+++ b/src/main/java/org/jahia/modules/tools/security/ToolsAccessGuard.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.tools.security;
+
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.JCRTemplate;
+import org.jahia.services.usermanager.JahiaUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Single source of truth for the tools authorization check. Evaluated at the resource (inside the tool JSPs) as a
+ * second layer of defense that does not depend on any URL-pattern matching: it fires however the request was routed.
+ */
+public final class ToolsAccessGuard {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ToolsAccessGuard.class);
+
+    /** JCR node the tools access permission is evaluated against. */
+    private static final String TOOLS_PERMISSION_NODE = "/tools";
+
+    /** Privilege required to use the support tools, identical to the Shiro rule {@code perms[/tools:systemToolsAccess]}. */
+    private static final String TOOLS_PERMISSION = "systemToolsAccess";
+
+    private ToolsAccessGuard() {
+        // utility class
+    }
+
+    /**
+     * Checks, as the currently-connected user, whether they are allowed to use the support tools. Any missing user or
+     * error while resolving the permission is treated as a denial (default-deny).
+     *
+     * @return {@code true} only if the connected user holds {@code systemToolsAccess} on {@code /tools}
+     */
+    public static boolean isGranted() {
+        JahiaUser currentUser = JCRSessionFactory.getInstance().getCurrentUser();
+        if (currentUser == null) {
+            return false;
+        }
+        try {
+            return JCRTemplate.getInstance().doExecute(currentUser, null, null, session -> {
+                // An unauthorized caller (the guest user, or a logged-in user without the privilege) cannot even
+                // read /tools. Probe visibility first: calling getNode() on an invisible node throws
+                // PathNotFoundException, which would turn every ordinary anonymous request into a noisy WARN with a
+                // stack trace. A missing or invisible node simply means "not granted".
+                if (!session.nodeExists(TOOLS_PERMISSION_NODE)) {
+                    return false;
+                }
+                return session.getNode(TOOLS_PERMISSION_NODE).hasPermission(TOOLS_PERMISSION);
+            });
+        } catch (Exception e) {
+            // Reaching here now means an unexpected failure (not the ordinary unauthorized case), so WARN is warranted.
+            LOGGER.warn("Unexpected error while evaluating tools access for user {}, denying access", currentUser.getName(), e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/tools/taglibs/RequireToolsAccessTag.java
+++ b/src/main/java/org/jahia/modules/tools/taglibs/RequireToolsAccessTag.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.tools.taglibs;
+
+import org.jahia.modules.tools.security.ToolsAccessGuard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.SkipPageException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import java.io.IOException;
+
+/**
+ * Enforces, at the very top of every tool JSP, that the connected user is authorized to use the support tools. On
+ * denial it returns {@code 403 Forbidden} and aborts the page, so none of the page's privileged operations run.
+ *
+ * @see ToolsAccessGuard
+ */
+public class RequireToolsAccessTag extends SimpleTagSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequireToolsAccessTag.class);
+
+    @Override
+    public void doTag() throws JspException, IOException {
+        if (ToolsAccessGuard.isGranted()) {
+            return;
+        }
+        PageContext pageContext = (PageContext) getJspContext();
+        HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
+        HttpServletResponse response = (HttpServletResponse) pageContext.getResponse();
+        if (LOGGER.isWarnEnabled()) {
+            LOGGER.warn("Denying unauthorized access to tools resource {}", request.getRequestURI());
+        }
+        if (!response.isCommitted()) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        }
+        // Abort the rest of the page so no privileged work runs.
+        throw new SkipPageException();
+    }
+}

--- a/src/main/resources/META-INF/tools.tld
+++ b/src/main/resources/META-INF/tools.tld
@@ -10,6 +10,13 @@
     <tlib-version>1.0</tlib-version>
     <short-name>tools</short-name>
     <uri>http://www.jahia.org/tags/tools</uri>
+    <tag>
+        <description>Enforces that the connected user holds systemToolsAccess on /tools; sends 403 and aborts the page
+            otherwise. Must be the first executable statement of every tool JSP.</description>
+        <name>requireToolsAccess</name>
+        <tag-class>org.jahia.modules.tools.taglibs.RequireToolsAccessTag</tag-class>
+        <body-content>empty</body-content>
+    </tag>
     <function>
         <description>Returns a collection of BundleResource, representing scripts, which are found in all active module bundles.</description>
         <name>getGroovyConsoleScripts</name>

--- a/src/main/resources/actions.jsp
+++ b/src/main/resources/actions.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.jahia.registries.ServicesRegistry"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>

--- a/src/main/resources/benchmarks.jsp
+++ b/src/main/resources/benchmarks.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-        %><?xml version="1.0" encoding="UTF-8" ?>
+        %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.apache.commons.lang.StringUtils"%>
 <%@ page import="org.apache.jackrabbit.core.id.NodeId" %>

--- a/src/main/resources/cache.jsp
+++ b/src/main/resources/cache.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="net.sf.ehcache.Cache" %>
 <%@page import="net.sf.ehcache.CacheManager" %>

--- a/src/main/resources/checklocks.jsp
+++ b/src/main/resources/checklocks.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.ajax.gwt.helper.CacheHelper" %>
 <%@ page import="org.jahia.api.Constants" %>

--- a/src/main/resources/choicelistInitializersRenderers.jsp
+++ b/src/main/resources/choicelistInitializersRenderers.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.services.content.nodetypes.initializers.ChoiceListInitializerService" %>
 <%@ page import="java.util.Map" %>

--- a/src/main/resources/ckeditorConfig.jsp
+++ b/src/main/resources/ckeditorConfig.jsp
@@ -1,5 +1,6 @@
 <%@page import="org.apache.commons.io.Charsets,org.apache.commons.io.FileUtils,org.jahia.osgi.BundleUtils,org.jahia.settings.SettingsBean"
-%>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="org.osgi.framework.Bundle" %>
 <%@ page import="org.osgi.framework.Version" %>
 <%@ page import="java.io.File" %>

--- a/src/main/resources/dbQuery.jsp
+++ b/src/main/resources/dbQuery.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>

--- a/src/main/resources/definitionsBrowser.jsp
+++ b/src/main/resources/definitionsBrowser.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.services.content.nodetypes.NodeTypeRegistry" %>
 <%@ page import="javax.jcr.nodetype.NodeType"%>

--- a/src/main/resources/docConverter.jsp
+++ b/src/main/resources/docConverter.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@page import="org.jahia.services.transform.DocumentConverterService"%>

--- a/src/main/resources/ehcache/ehcache_cj.jsp
+++ b/src/main/resources/ehcache/ehcache_cj.jsp
@@ -1,4 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="net.sf.ehcache.Ehcache" %>
 <%@ page import="net.sf.ehcache.Element" %>
 <%@ page import="org.apache.commons.io.FileUtils" %>

--- a/src/main/resources/ehcache/ehcache_cj_dep.jsp
+++ b/src/main/resources/ehcache/ehcache_cj_dep.jsp
@@ -1,4 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="net.sf.ehcache.Ehcache" %>
 <%@ page import="net.sf.ehcache.Element" %>
 <%@ page import="org.jahia.services.cache.CacheEntry" %>

--- a/src/main/resources/ehcache/ehcache_details.jsp
+++ b/src/main/resources/ehcache/ehcache_details.jsp
@@ -1,4 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="net.sf.ehcache.Ehcache" %>
 <%@ page import="net.sf.ehcache.Element" %>
 <%@ page import="org.apache.commons.io.FileUtils" %>

--- a/src/main/resources/ehcache/ehcache_dump.jsp
+++ b/src/main/resources/ehcache/ehcache_dump.jsp
@@ -1,4 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="net.sf.ehcache.Ehcache" %>
 <%@ page import="net.sf.ehcache.Element" %>
 <%@ page import="org.apache.commons.lang.StringEscapeUtils" %>

--- a/src/main/resources/ehcache/ehcache_stats.jsp
+++ b/src/main/resources/ehcache/ehcache_stats.jsp
@@ -1,4 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="net.sf.ehcache.Ehcache" %>
 <%@ page import="net.sf.ehcache.Element" %>
 <%@ page import="org.jahia.services.cache.CacheEntry" %>

--- a/src/main/resources/errorFileDumper.jsp
+++ b/src/main/resources/errorFileDumper.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.settings.SettingsBean" %>
 <%@ page import="org.jahia.bin.errors.ErrorFileDumper" %>

--- a/src/main/resources/groovyConsole.jsp
+++ b/src/main/resources/groovyConsole.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@ page import="org.apache.commons.io.FileUtils" %>
@@ -25,7 +26,6 @@
 <%@ page import="org.jahia.modules.tools.taglibs.GroovyConsoleHelper" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
-<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools" %>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Groovy Console</title>

--- a/src/main/resources/importPackageChecker.jsp
+++ b/src/main/resources/importPackageChecker.jsp
@@ -1,4 +1,5 @@
-<%@ page import="org.jahia.modules.tools.gql.admin.osgi.OSGIPackageHeaderChecker" %>
+<%@ page import="org.jahia.modules.tools.gql.admin.osgi.OSGIPackageHeaderChecker" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="org.jahia.modules.tools.gql.admin.osgi.FindImportPackage" %>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/src/main/resources/index.jsp
+++ b/src/main/resources/index.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@page import="java.util.Date"%>

--- a/src/main/resources/jcrBrowser.jsp
+++ b/src/main/resources/jcrBrowser.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-        %><?xml version="1.0" encoding="UTF-8" ?>
+        %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="javax.jcr.nodetype.PropertyDefinition"%>
 <%@page import="javax.jcr.version.Version" %>

--- a/src/main/resources/jcrConsole.jsp
+++ b/src/main/resources/jcrConsole.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@page import="java.util.Locale"%>

--- a/src/main/resources/jcrExternalProviders.jsp
+++ b/src/main/resources/jcrExternalProviders.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-        %><?xml version="1.0" encoding="UTF-8" ?>
+        %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 

--- a/src/main/resources/jcrGc.jsp
+++ b/src/main/resources/jcrGc.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@ page import="org.jahia.services.content.JCRContentUtils" %>

--- a/src/main/resources/jcrIntegrityTools.jsp
+++ b/src/main/resources/jcrIntegrityTools.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.ajax.gwt.helper.CacheHelper" %>

--- a/src/main/resources/jcrJarsCleanup.jsp
+++ b/src/main/resources/jcrJarsCleanup.jsp
@@ -1,4 +1,5 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="org.slf4j.Logger"%>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="org.jahia.osgi.BundleUtils" %>

--- a/src/main/resources/jcrQuery.jsp
+++ b/src/main/resources/jcrQuery.jsp
@@ -1,4 +1,5 @@
-<%@page contentType="text/html;charset=UTF-8" language="java" %>
+<%@page contentType="text/html;charset=UTF-8" language="java" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.apache.commons.lang.StringUtils" %>

--- a/src/main/resources/jcrQueryStats.jsp
+++ b/src/main/resources/jcrQueryStats.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.apache.jackrabbit.core.JahiaRepositoryImpl"%>
 <%@page import="org.jahia.services.content.impl.jackrabbit.SpringJackrabbitRepository"%>

--- a/src/main/resources/jcrSessions.jsp
+++ b/src/main/resources/jcrSessions.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.services.content.JCRSessionWrapper" buffer="16kb" %>
 <%@ page import="java.io.PrintWriter" %>

--- a/src/main/resources/jcrVersionHistory.jsp
+++ b/src/main/resources/jcrVersionHistory.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@page import="java.util.*"%>

--- a/src/main/resources/jobInfo.jsp
+++ b/src/main/resources/jobInfo.jsp
@@ -1,5 +1,6 @@
 <%@ page import="org.jahia.registries.ServicesRegistry, org.jahia.services.scheduler.*, java.text.*, java.util.*, org.quartz.*"
-%><%
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><%
 SchedulerService service = ServicesRegistry.getInstance().getSchedulerService();
 Scheduler scheduler = service.getScheduler();
 pageContext.setAttribute("service", service);

--- a/src/main/resources/jobadmin.jsp
+++ b/src/main/resources/jobadmin.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.bin.Jahia" %>
 <%@ page import="org.jahia.registries.ServicesRegistry" %>

--- a/src/main/resources/karaf.jsp
+++ b/src/main/resources/karaf.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>

--- a/src/main/resources/loadAverage.jsp
+++ b/src/main/resources/loadAverage.jsp
@@ -1,4 +1,5 @@
-<%@page import="org.jahia.exceptions.JahiaBadRequestException"%>
+<%@page import="org.jahia.exceptions.JahiaBadRequestException"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" 
 %><% response.setContentType("json".equals(request.getParameter("output")) ? "application/json; charset=UTF-8" : "text/plain; charset=UTF-8"); 
 %><%@page import="org.jahia.utils.*"

--- a/src/main/resources/log4jAdmin.jsp
+++ b/src/main/resources/log4jAdmin.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <%@ page import="java.util.*" %>

--- a/src/main/resources/maintenance.jsp
+++ b/src/main/resources/maintenance.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.bin.Jahia" %>
 <%@ page import="org.jahia.services.SpringContextSingleton" %>

--- a/src/main/resources/memoryInfo.jsp
+++ b/src/main/resources/memoryInfo.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="java.io.StringWriter"%>
 <%@page import="java.io.PrintWriter"%>

--- a/src/main/resources/modules.jsp
+++ b/src/main/resources/modules.jsp
@@ -1,4 +1,5 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %><?xml version="1.0" encoding="UTF-8" ?>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="java.io.StringWriter" %>
 <%@page import="java.io.PrintWriter" %>

--- a/src/main/resources/modulesBrowser.jsp
+++ b/src/main/resources/modulesBrowser.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.apache.commons.io.FileUtils" %>
 <%@page import="org.jahia.data.templates.JahiaTemplatesPackage" %>

--- a/src/main/resources/nodesVersusCndConsistency.jsp
+++ b/src/main/resources/nodesVersusCndConsistency.jsp
@@ -1,4 +1,5 @@
-<%@ page import="java.io.IOException" %>
+<%@ page import="java.io.IOException" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ page import="java.io.PrintWriter" %>
 <%@ page import="java.text.MessageFormat" %>
 <%@ page import="java.util.ArrayList" %>

--- a/src/main/resources/pwdEncrypt.jsp
+++ b/src/main/resources/pwdEncrypt.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@ page import="org.jahia.utils.EncryptionUtils" %>

--- a/src/main/resources/render.jsp
+++ b/src/main/resources/render.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@ page import="org.jahia.services.render.RenderInfo" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>

--- a/src/main/resources/renderDump.jsp
+++ b/src/main/resources/renderDump.jsp
@@ -1,4 +1,5 @@
-<%@ page import="org.jahia.services.render.RenderInfo" %><%
+<%@ page import="org.jahia.services.render.RenderInfo" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><%
     response.setContentType("application/json");
     response.setHeader("Content-Disposition","attachment; filename=\"dump.json\"");
     String s = RenderInfo.dump();

--- a/src/main/resources/renderFilters.jsp
+++ b/src/main/resources/renderFilters.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-        %><?xml version="1.0" encoding="UTF-8" ?>
+        %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.jahia.services.render.RenderService"%>
 <%@ page import="org.jahia.services.render.filter.RenderFilter" %>

--- a/src/main/resources/rules.jsp
+++ b/src/main/resources/rules.jsp
@@ -1,4 +1,5 @@
-<%@page import="org.drools.core.base.EnabledBoolean"%>
+<%@page import="org.drools.core.base.EnabledBoolean"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@page import="org.drools.core.spi.Enabled"%>
 <%@page import="org.drools.core.rule.Rule"%>
 <%@page import="java.lang.reflect.Field"%>

--- a/src/main/resources/search.jsp
+++ b/src/main/resources/search.jsp
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="java.io.File"%>
 <%@page import="java.io.FileFilter"%>

--- a/src/main/resources/searchIndexCheck.jsp
+++ b/src/main/resources/searchIndexCheck.jsp
@@ -1,4 +1,5 @@
-<%@page import="java.io.File"%>
+<%@page import="java.io.File"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@page import="java.io.FileFilter"%>
 <%@page import="org.apache.commons.io.FileUtils"%>
 <%@page import="org.apache.commons.io.filefilter.DirectoryFileFilter"%>

--- a/src/main/resources/support.jsp
+++ b/src/main/resources/support.jsp
@@ -1,5 +1,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" 
-%><%@ page import="java.io.File, org.jahia.modules.tools.SupportInfoHelper" %><% File targetDir = new File(System.getProperty("jahia.log.dir"), "jahia-support").getCanonicalFile(); 
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><%@ page import="java.io.File, org.jahia.modules.tools.SupportInfoHelper" %><% File targetDir = new File(System.getProperty("jahia.log.dir"), "jahia-support").getCanonicalFile(); 
 %><c:if test="${param.action == 'download' || param.action == 'server'}"><% SupportInfoHelper.exportInfo(targetDir, request, response); %></c:if><c:if test="${param.action != 'download'}"><%@ page contentType="text/html;charset=UTF-8" language="java"
 %><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/src/main/resources/systemInfo.jsp
+++ b/src/main/resources/systemInfo.jsp
@@ -1,4 +1,5 @@
-<%@page import="java.io.PrintWriter,java.util.Date,java.text.SimpleDateFormat,org.jahia.bin.errors.ErrorFileDumper"%>
+<%@page import="java.io.PrintWriter,java.util.Date,java.text.SimpleDateFormat,org.jahia.bin.errors.ErrorFileDumper"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core"  prefix="c"
 %><c:if test="${param.file}"><%
 response.setContentType("text/plain; charset=ISO-8859-1");

--- a/src/main/resources/textExtractor.jsp
+++ b/src/main/resources/textExtractor.jsp
@@ -1,4 +1,5 @@
-<%@ page contentType="text/html; charset=UTF-8" language="java"%>
+<%@ page contentType="text/html; charset=UTF-8" language="java"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/main/resources/threadDump.jsp
+++ b/src/main/resources/threadDump.jsp
@@ -1,4 +1,5 @@
-<%@page import="java.io.PrintWriter,java.util.Date,java.text.SimpleDateFormat,org.jahia.bin.errors.ErrorFileDumper"%> 
+<%@page import="java.io.PrintWriter,java.util.Date,java.text.SimpleDateFormat,org.jahia.bin.errors.ErrorFileDumper"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/> 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core"  prefix="c" 
 %><c:if test="${param.file}"><%
 response.setContentType("text/plain; charset=ISO-8859-1");

--- a/src/main/resources/threadDumpMgmt.jsp
+++ b/src/main/resources/threadDumpMgmt.jsp
@@ -1,4 +1,5 @@
-<%@page import="org.jahia.utils.LoadAverage"%>
+<%@page import="org.jahia.utils.LoadAverage"%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <%@page import="org.jahia.services.SpringContextSingleton"%>
 <%@ page contentType="text/html;charset=UTF-8" language="java"
 %><?xml version="1.0" encoding="UTF-8" ?>

--- a/src/main/resources/viewsession.jsp
+++ b/src/main/resources/viewsession.jsp
@@ -1,4 +1,5 @@
-<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%@ page language="java" contentType="text/html;charset=UTF-8" %><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/main/resources/wcagChecker.jsp
+++ b/src/main/resources/wcagChecker.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>

--- a/src/main/resources/workflows.jsp
+++ b/src/main/resources/workflows.jsp
@@ -1,5 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java"
-%><?xml version="1.0" encoding="UTF-8" ?>
+%><%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools"
+%><tools:requireToolsAccess/><?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <%@page import="org.apache.commons.lang.StringUtils" %>
 <%@page import="org.jahia.services.content.JCRSessionFactory" %>

--- a/src/test/java/org/jahia/modules/tools/taglibs/RequireToolsAccessTagTest.java
+++ b/src/test/java/org/jahia/modules/tools/taglibs/RequireToolsAccessTagTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.tools.taglibs;
+
+import org.jahia.modules.tools.security.ToolsAccessGuard;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.SkipPageException;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the denial contract of {@link RequireToolsAccessTag}: the tag is the guard's only enforcement point once a
+ * request reaches a JSP, so it must send {@code 403} and abort the page for an unauthorized user, and let an authorized
+ * user through untouched. The authorization decision itself ({@link ToolsAccessGuard#isGranted()}) is stubbed here; its
+ * own logic is out of scope for this unit.
+ */
+public class RequireToolsAccessTagTest {
+
+    private RequireToolsAccessTag tag;
+    private PageContext pageContext;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+
+    @Before
+    public void setUp() {
+        tag = new RequireToolsAccessTag();
+        pageContext = mock(PageContext.class);
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        when(pageContext.getRequest()).thenReturn(request);
+        when(pageContext.getResponse()).thenReturn(response);
+        tag.setJspContext(pageContext);
+    }
+
+    @Test
+    public void deniesUnauthorizedWith403AndAbortsPage() throws Exception {
+        try (MockedStatic<ToolsAccessGuard> guard = Mockito.mockStatic(ToolsAccessGuard.class)) {
+            guard.when(ToolsAccessGuard::isGranted).thenReturn(false);
+            when(response.isCommitted()).thenReturn(false);
+
+            assertThrows(SkipPageException.class, () -> tag.doTag());
+
+            verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+        }
+    }
+
+    @Test
+    public void allowsAuthorizedUserWithoutTouchingTheResponse() throws Exception {
+        try (MockedStatic<ToolsAccessGuard> guard = Mockito.mockStatic(ToolsAccessGuard.class)) {
+            guard.when(ToolsAccessGuard::isGranted).thenReturn(true);
+
+            tag.doTag(); // must return normally, letting the page render
+
+            verify(response, never()).sendError(Mockito.anyInt());
+        }
+    }
+
+    @Test
+    public void abortsWithoutWritingWhenResponseAlreadyCommitted() throws Exception {
+        try (MockedStatic<ToolsAccessGuard> guard = Mockito.mockStatic(ToolsAccessGuard.class)) {
+            guard.when(ToolsAccessGuard::isGranted).thenReturn(false);
+            when(response.isCommitted()).thenReturn(true);
+
+            // The page must still be aborted, but we cannot send an error once the response is committed.
+            assertThrows(SkipPageException.class, () -> tag.doTag());
+
+            verify(response, never()).sendError(Mockito.anyInt());
+        }
+    }
+}


### PR DESCRIPTION
Backport of 129c732c (#329) to the `4_x` / Jahia 8.1.6 line.

## Why

The tools-access permission was enforced only at the perimeter, by the Shiro filter chain matching on the request URL. This adds a second, independent layer evaluated at the resource itself, so it fires however the request was routed.

## The 8.1.6 security model is identical to 8.2

`JahiaAccountRealm.isPermitted()` in `jahia-impl-8.1.6.0` does exactly what `ToolsAccessGuard` reproduces:

```java
JCRTemplate.getInstance().doExecute(jahiaUser, null, null,
    session -> session.getNode(permissionOnPath.getNode()).hasPermission(permissionOnPath.getPermission()));
```

`applicationcontext-security.xml` carries the same rules, including `/modules/tools/** = authcJahia, perms[/tools:systemToolsAccess]`. Diffing that file and `JahiaAccountRealm` between 8.1.6.0 and 8.2.0.0 shows only cosmetic differences, with one exception that matters: `blockSemicolon` is hardcoded `false` in 8.1.6 vs `${shiro.blockSemicolon:true}` in 8.2. The perimeter is *weaker* on 8.1.6, so this defense-in-depth layer is more valuable here, not less.

The guard is therefore the upstream code unchanged.

## What is in it

- `ToolsAccessGuard` — single source of truth for the check, default-deny on any error.
- `RequireToolsAccessTag` (`tools:requireToolsAccess`) — sends 403 and aborts the page via `SkipPageException`; added as the first executable element of all 53 tool JSPs.
- `JspPrecompileServlet` — same check, since it is registered directly on the `HttpService` rather than served as a JSP.

## Adaptations needed for this branch

- **Mockito pinned to the 4.x line** (`mockito-inline`, for the static-mock support the test needs). `4_x` compiles with `source/target 1.8` and builds/releases on `openjdk_8.0.312`, which Mockito 5 dropped. `jsp-api` needs no version, the 8.1.6.0 parent manages it.
- **Whitespace-neutral JSP inserts.** Unlike `main`, these pages keep their XHTML prolog at byte 0 using newline-suppressing `%>` continuations, so the guard is inserted immediately after the leading directive with no emitted output, respecting each file's line endings (25 of 53 are CRLF).

Note `4_x` has `loadAverage.jsp`, absent from `main` — it is guarded too. `main` has `packageWiresAnalyzer.jsp` / `provisioning.jsp`, which do not exist here.

## Verification

All 53 JSPs were run through Jasper (translation only, using the module's Maven classpath), comparing the pristine tree against the modified one:

- 53/53 translate in both trees, identical results.
- The guard is the first executable element of every page, confirmed in the generated servlets (`if (_jspx_meth_tools_...) return;` ahead of any `out.write`).
- Comparing the emitted `out.write` literals page by page: exactly one page changes output — `groovyConsole.jsp`, by a single newline, where the now-redundant `tools` taglib declaration was removed (as upstream did). The other 52 are byte-identical.

`mvn clean test` compiles and passes 3/3.

`mvn package` fails locally at `jahia-maven-plugin:6.7:dependencies` (`ClassNotFoundException: ParsingContext`). Verified pre-existing on the pristine tree — a local environment issue (Maven 3.9.6 / JDK 17), unrelated to this change. CI on JDK 8 covers packaging.

## Not backported

- The **Cypress spec** (`toolsAccess.spec.ts` and the `TOOL_JSPS` list). This branch has no `tests/` directory and no integration-test CI job to host it; adding one means building the whole test stack, which is beyond a backport. Happy to do it separately.
- `.chachalog/` (this branch releases via `maven-release-plugin`) and the node-build `.gitignore` entries (no frontend build here).
- `jahia-module-signature` is left to the `update-signature` CI job.
