### PR TITLE
fix: encode the node path in the JCR query results Repository Explorer link

### DIFF
--- a/src/main/resources/jcrQuery.jsp
+++ b/src/main/resources/jcrQuery.jsp
@@ -420,7 +420,7 @@
                                    target="_blank"><strong>${fn:escapeXml(not empty node.displayableName ? node.name : '<root>')}</strong></a>
                                 (${fn:escapeXml(node.nodeTypes)})
                                 <a title="Open in Repository Explorer"
-                                   href="<c:url value='/engines/manager.jsp?selectedPaths=${node.path}&workspace=${workspace}'/>"
+                                   href="<c:url value='/engines/manager.jsp?selectedPaths=${fn:escapeXml(functions:escapePath(node.path))}&workspace=${workspace}'/>"
                                    target="_blank"><img src="<c:url value='/icons/fileManager.png'/>" width="16"
                                                         height="16" alt="open" title="Open in Repository Explorer"></a>
                                 <c:if test="${showActions}">
@@ -464,7 +464,7 @@
                                        href="<c:url value='jcrBrowser.jsp?uuid=${node.identifier}&workspace=${workspace}&showProperties=true&toolAccessToken=${toolAccessToken}'/>"
                                        target="_blank"><strong>${fn:escapeXml(not empty node.displayableName ? node.name : '<root>')}</strong></a> (${fn:escapeXml(node.nodeTypes)})
                                     <a title="Open in Repository Explorer"
-                                       href="<c:url value='/engines/manager.jsp?selectedPaths=${node.path}&workspace=${workspace}&toolAccessToken=${toolAccessToken}'/>"
+                                       href="<c:url value='/engines/manager.jsp?selectedPaths=${fn:escapeXml(functions:escapePath(node.path))}&workspace=${workspace}&toolAccessToken=${toolAccessToken}'/>"
                                        target="_blank"><img src="<c:url value='/icons/fileManager.png'/>" width="16"
                                                             height="16" alt="open" title="Open in Repository Explorer"></a>
                                     <c:if test="${showActions}">


### PR DESCRIPTION
Backport of #341 onto the `4_x` maintenance line.

## Summary

The JCR-query results page writes each result node's JCR path straight into the `href` of the
"Open in Repository Explorer" link. `<c:url>` performs context-path rewriting and
`response.encodeURL()` only — it does **not** encode the EL interpolated into it — so a node whose
local name contains `"`, `<`, `>` or `&` produces a broken `href` and malformed markup.

The same page already emits the node path correctly elsewhere: the "Path:" display lines use
`${fn:escapeXml(node.path)}`, and the node name in the delete `onclick` is escaped. Only these two
link `href`s were left unencoded, so the page was internally inconsistent.

## Change

Both `href`s now read:

```jsp
selectedPaths=${fn:escapeXml(functions:escapePath(node.path))}
```

`functions:escapePath` (`org.jahia.utils.WebUtils.escapePath` → Jackrabbit `Text.escapePath`)
URL-encodes each path segment and **leaves the separators**, so `selectedPaths` stays a usable path;
`fn:escapeXml` then wraps it for the surrounding attribute. This mirrors the
`fn:escapeXml(functions:escapeJavaScript(…))` pairing already used on the node name in this file.

Identical to #341 on `main`, re-applied by hand because the file sits at
`src/main/resources/jcrQuery.jsp` on this line (it moved to `impl/src/main/resources/` in the
multi-module migration) and the line numbers differ.

## Verification

- **On `main` (#341): deploy-verified.** The module was built and deployed to a running 8.2.4.0-SNAPSHOT
  instance, and the rendered page was checked directly: a node whose local name contains `"><…>`
  now renders `selectedPaths=/…/%22%3e%3c…` in the `href` instead of terminating the attribute early,
  with no live element produced. Confirmed with a positive control — the row **is** still rendered, so
  the check is not passing vacuously on an empty result set. An ordinary path renders byte-unchanged
  (`selectedPaths=/sites/systemsite/home`), so the link keeps working.
- **On this line: reviewed, not deployed.** The two prerequisites were checked explicitly rather than
  assumed:
  - `functions:escapePath` **exists** in the 8.1 taglib — present in `functions.tld` at both
    `JAHIA_8_1_6_0` (this line's parent) and `JAHIA_8_1_9_0`, same signature, and its implementation
    is the same one-line delegation to `Text.escapePath`.
  - the `functions` prefix is **already declared** in this JSP (`:29`), so no new taglib directive is
    needed and the page still compiles.
- Nothing in this repo's build compiles this JSP's body (there is no `jspc` step, and the integration
  suite renders only `index.jsp` / `jcrBrowser.jsp`), which is why the two points above were verified
  against the 8.1 taglib rather than inferred from `main`.

## Note

A regression test for this page is still owed and is **not** in this PR — the same gap as on `main`.
