### PR TITLE
fix: hardened groovy scripts execution

### DIFF
--- a/.chachalog/XE41p3xu.md
+++ b/.chachalog/XE41p3xu.md
@@ -1,0 +1,5 @@
+---
+# Allowed version bumps: patch, minor, major
+tools: patch
+---
+Restricted the Groovy console scriptURI parameter to the scripts packaged in active module bundles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tools Changelog
 
+## 5.5.0
+
+### Bug Fixes
+
+* Restricted the Groovy console `scriptURI` parameter to the scripts packaged in active module bundles. It used to be opened as a URL, so `file://` and `http://` values turned it into an arbitrary file read, a server-side request forgery and a remote code execution vector, since whatever it returned was executed by the Groovy engine. Unknown values are now rejected with a `400`, and the script content shown in the preview is HTML-escaped.
+
 ## 5.4.0
 
 ### New Features

--- a/impl/src/main/java/org/jahia/modules/tools/taglibs/GroovyConsoleHelper.java
+++ b/impl/src/main/java/org/jahia/modules/tools/taglibs/GroovyConsoleHelper.java
@@ -26,6 +26,7 @@ import org.springframework.core.io.UrlResource;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
 
@@ -38,6 +39,11 @@ public class GroovyConsoleHelper {
 
     public static final String WARN_MSG = "WARNING: You are about to execute a script, which can manipulate the repository data or execute services in Jahia. Are you sure, you want to continue?";
     public static final String GROOVY_CONSOLE_FQCN = "org.jahia.tools.groovyConsole";
+
+    /** Value the console's script selector uses to mean "run the code typed in the textarea". */
+    public static final String CUSTOM_SCRIPT = "custom";
+
+    private static final int MAX_LOGGED_URI_LENGTH = 200;
 
     private static void generateCbFormElement(String paramName, StringBuilder sb, Properties confs,
             HttpServletRequest request) {
@@ -367,33 +373,101 @@ public class GroovyConsoleHelper {
     }
 
     /**
+     * Tells whether the requested script URI designates the custom script, i.e. the code typed into the console's
+     * textarea, rather than one of the predefined scripts.
+     *
+     * @param scriptURI the requested script URI
+     * @return <code>true</code> if the console has to run the code coming from the textarea
+     */
+    public static boolean isCustomScript(String scriptURI) {
+        return StringUtils.isBlank(scriptURI) || CUSTOM_SCRIPT.equals(scriptURI);
+    }
+
+    /**
+     * Resolves a requested script URI into the corresponding script registered by an active module bundle.
+     * <p>
+     * The console's selector offers nothing but those scripts, so any other value is a forged request. Callers must
+     * read the script through the returned resource instead of opening the requested URI: that is what keeps
+     * <code>file://</code>, <code>http://</code> and <code>classpath:</code> URIs from being fetched and handed over
+     * to the Groovy engine.
+     *
+     * @param scriptURI the requested script URI
+     * @return the registered script matching the URI, or <code>null</code> if no active module bundle registers it,
+     *         which includes the custom script case
+     */
+    public static BundleResource resolveScript(String scriptURI) {
+        if (isCustomScript(scriptURI)) {
+            return null;
+        }
+        for (final BundleResource script : getGroovyConsoleScripts()) {
+            if (scriptURI.equals(getURI(script))) {
+                return script;
+            }
+        }
+        logger.warn("Rejected the Groovy console script URI {}: no active module bundle registers it",
+                sanitizeForLog(scriptURI));
+        return null;
+    }
+
+    private static String getURI(BundleResource script) {
+        try {
+            return script.getURI().toString();
+        } catch (IOException e) {
+            logger.error("Unable to get the URI of the Groovy console script " + script.getFilename(), e);
+            return null;
+        }
+    }
+
+    private static String sanitizeForLog(String value) {
+        return StringUtils.abbreviate(value.replaceAll("[\\r\\n]", " "), MAX_LOGGED_URI_LENGTH);
+    }
+
+    /**
+     * Loads the configuration declared by the sibling <code>.properties</code> file of the requested script, or
+     * <code>null</code> if the script is not registered by any active module bundle or declares no configuration. The
+     * properties file is looked up next to the registered script rather than next to the requested URI.
+     */
+    private static Properties loadScriptConfiguration(BundleResource script) {
+        if (script == null) {
+            return null;
+        }
+        try {
+            final UrlResource resource = new UrlResource(
+                    StringUtils.substringBeforeLast(script.getURL().toExternalForm(), ".groovy") + ".properties");
+            if (!resource.exists()) {
+                return null;
+            }
+            final Properties confs = new Properties();
+            try (InputStream is = resource.getInputStream()) {
+                confs.load(is);
+            }
+            return confs;
+        } catch (IOException e) {
+            logger.error("An error occured while reading the configurations for the script " + script.getFilename(), e);
+            return null;
+        }
+    }
+
+    private static String[] getParamNames(Properties confs) {
+        return StringUtils.split(confs.getProperty("script.parameters.names", "").replaceAll("\\s", ""), ",");
+    }
+
+    /**
      * Returns a generated HTML with form elements for the script parameters.
      *
-     * @param scriptURI
-     * @param request
-     * @return
+     * @param scriptURI the requested script URI
+     * @param request the current request, holding the submitted parameter values
+     * @return the form elements, or an empty string if the script is not registered by any active module bundle or
+     *         declares no parameter
      */
     public static String getScriptCustomFormElements(String scriptURI, HttpServletRequest request) {
-        if (StringUtils.isBlank(scriptURI)) {
+        final Properties confs = loadScriptConfiguration(resolveScript(scriptURI));
+        if (confs == null) {
             return StringUtils.EMPTY;
         }
         final StringBuilder sb = new StringBuilder();
-        try {
-            final UrlResource resource = new UrlResource(
-                    StringUtils.substringBeforeLast(scriptURI, ".groovy") + ".properties");
-            if (resource.exists()) {
-                final Properties confs = new Properties();
-                confs.load(resource.getInputStream());
-                final String[] paramNames = StringUtils
-                        .split(confs.getProperty("script.parameters.names", "").replaceAll("\\s", ""), ",");
-                for (String paramName : paramNames) {
-                    generateFormElement(paramName.trim(), sb, confs, request);
-                }
-
-            }
-        } catch (IOException e) {
-            logger.error("An error occured while reading the configurations for the script " + scriptURI, e);
-            return StringUtils.EMPTY;
+        for (final String paramName : getParamNames(confs)) {
+            generateFormElement(paramName.trim(), sb, confs, request);
         }
         final String formElements = sb.toString();
         if (StringUtils.isBlank(formElements)) {
@@ -406,21 +480,11 @@ public class GroovyConsoleHelper {
     /**
      * Returns an array of parameter names for the specified script or <code>null</code> if the script has no parameters.
      *
-     * @param scriptURI the script URI to get parameter names for
+     * @param script the script, as resolved by {@link #resolveScript(String)}, to get parameter names for
      * @return an array of parameter names for the specified script or <code>null</code> if the script has no parameters
      */
-    public static String[] getScriptParamNames(String scriptURI) {
-        try {
-            final UrlResource resource = new UrlResource(
-                    StringUtils.substringBeforeLast(scriptURI, ".groovy") + ".properties");
-            if (resource.exists()) {
-                final Properties confs = new Properties();
-                confs.load(resource.getInputStream());
-                return StringUtils.split(confs.getProperty("script.parameters.names", "").replaceAll("\\s", ""), ",");
-            }
-        } catch (IOException e) {
-            logger.error("An error occured while reading the configurations for the script " + scriptURI, e);
-        }
-        return null;
+    public static String[] getScriptParamNames(BundleResource script) {
+        final Properties confs = loadScriptConfiguration(script);
+        return confs != null ? getParamNames(confs) : null;
     }
 }

--- a/impl/src/main/resources/groovyConsole.jsp
+++ b/impl/src/main/resources/groovyConsole.jsp
@@ -1,12 +1,23 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java" %>
+<%@ page import="org.jahia.modules.tools.taglibs.GroovyConsoleHelper" %>
+<%@ page import="org.jahia.osgi.BundleResource" %>
 <%@ taglib prefix="tools" uri="http://www.jahia.org/tags/tools" %>
 <tools:requireToolsAccess/>
+<%
+    // A script URI only ever designates a script packaged in an active module bundle, so resolve it against that
+    // registry and read it through the resolved resource. Opening the requested URI itself would let file://,
+    // http:// or classpath: content be fetched and executed by the Groovy engine below.
+    final String scriptURI = request.getParameter("scriptURI");
+    final BundleResource selectedScript = GroovyConsoleHelper.resolveScript(scriptURI);
+    if (selectedScript == null && !GroovyConsoleHelper.isCustomScript(scriptURI)) {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unknown script");
+        return;
+    }
+%>
 <!DOCTYPE html>
 <html>
 <%@ page import="org.apache.commons.io.FileUtils" %>
-<%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.jahia.bin.listeners.LoggingConfigListener" %>
-<%@ page import="org.jahia.modules.tools.taglibs.GroovyConsoleHelper" %>
 <%@ page import="org.jahia.registries.ServicesRegistry" %>
 <%@ page import="org.jahia.services.scheduler.BackgroundJob" %>
 <%@ page import="org.jahia.services.scheduler.JSR223ScriptJob" %>
@@ -16,7 +27,6 @@
 <%@ page import="org.quartz.SchedulerException" %>
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
-<%@ page import="org.springframework.core.io.UrlResource" %>
 <%@ page import="javax.script.*" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.io.PrintWriter" %>
@@ -36,12 +46,10 @@
     ScriptEngine engine = null;
     try {
         engine = ScriptEngineUtils.getInstance().scriptEngine("groovy");
+        if (selectedScript != null) {
+            pageContext.setAttribute("scriptContent", org.jahia.utils.FileUtils.getContent(selectedScript));
+        }
 %>
-<c:if test="${not empty param.scriptURI && param.scriptURI != 'custom'}">
-    <%
-        pageContext.setAttribute("scriptContent", org.jahia.utils.FileUtils.getContent(new UrlResource(request.getParameter("scriptURI"))));
-    %>
-</c:if>
 <c:if test="${not empty param.runScript and param.runScript eq 'true'}">
     <%
         final StringBuilder code = GroovyConsoleHelper.generateScriptSkeleton();
@@ -54,13 +62,11 @@
             code.append("\n");
         }
 
-        final String scriptURL = request.getParameter("scriptURI");
-        boolean isPredefinedScript = false;
-        if (StringUtils.isBlank(scriptURL) || "custom".equals(scriptURL)) {
-            code.append(request.getParameter("script"));
-        } else {
+        final boolean isPredefinedScript = selectedScript != null;
+        if (isPredefinedScript) {
             code.append((String) pageContext.getAttribute("scriptContent"));
-            isPredefinedScript = true;
+        } else {
+            code.append(request.getParameter("script"));
         }
         if (executeInBackground) {
             File groovyConsole = File.createTempFile("groovyConsole", ".groovy");
@@ -86,7 +92,7 @@
                 bindings.put("log", lw);
                 bindings.put("logger", lw);
                 if (isPredefinedScript) {
-                    final String[] paramNames = GroovyConsoleHelper.getScriptParamNames(scriptURL);
+                    final String[] paramNames = GroovyConsoleHelper.getScriptParamNames(selectedScript);
                     if (paramNames != null) {
                         for (String paramName : paramNames) {
                             bindings.put(paramName, request.getParameter("scriptParam_" + paramName));
@@ -245,7 +251,7 @@
 <c:if test="${not empty scriptContent}">
     <div style="display: none;">
         <div id="viewArea">
-            <pre>${scriptContent}</pre>
+            <pre>${fn:escapeXml(scriptContent)}</pre>
         </div>
     </div>
 </c:if>

--- a/impl/src/test/java/org/jahia/modules/tools/taglibs/GroovyConsoleHelperTest.java
+++ b/impl/src/test/java/org/jahia/modules/tools/taglibs/GroovyConsoleHelperTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.tools.taglibs;
+
+import org.jahia.osgi.BundleResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the Groovy console only ever loads a script that an active module bundle registers.
+ * <p>
+ * The console executes the content it loads, so accepting an arbitrary {@code scriptURI} would turn the parameter into
+ * an SSRF, an arbitrary file read and a remote code execution vector at once. The registry of packaged scripts is the
+ * allowlist, and it is stubbed here since populating it needs a running OSGi container.
+ */
+public class GroovyConsoleHelperTest {
+
+    private static final String REGISTERED_URI = "bundle://157.0:1/META-INF/groovyConsole/registered.groovy";
+
+    private MockedStatic<GroovyConsoleHelper> helper;
+    private BundleResource registeredScript;
+
+    @Before
+    public void setUp() throws Exception {
+        registeredScript = mock(BundleResource.class);
+        when(registeredScript.getURI()).thenReturn(URI.create(REGISTERED_URI));
+        helper = Mockito.mockStatic(GroovyConsoleHelper.class, Mockito.CALLS_REAL_METHODS);
+        helper.when(GroovyConsoleHelper::getGroovyConsoleScripts)
+                .thenReturn(Arrays.asList(registeredScript));
+    }
+
+    @After
+    public void tearDown() {
+        helper.close();
+    }
+
+    @Test
+    public void resolvesAScriptPackagedInAnActiveModuleBundle() {
+        assertSame(registeredScript, GroovyConsoleHelper.resolveScript(REGISTERED_URI));
+    }
+
+    @Test
+    public void rejectsAnyURITheRegistryDoesNotOffer() throws Exception {
+        final String[] forgedURIs = {
+                "file:///etc/passwd",
+                "file:///tmp/evil.groovy",
+                "http://attacker.example:9999/evil.groovy",
+                "https://attacker.example/evil.groovy",
+                "ftp://attacker.example/evil.groovy",
+                "classpath:org/jahia/evil.groovy",
+                "bundle://157.0:1/META-INF/groovyConsole/unregistered.groovy",
+                REGISTERED_URI + "/../../../evil.groovy"
+        };
+        for (final String forgedURI : forgedURIs) {
+            assertNull("must not resolve " + forgedURI, GroovyConsoleHelper.resolveScript(forgedURI));
+        }
+        // A rejected URI is never opened: no request is issued and no file is read while deciding.
+        verify(registeredScript, never()).getInputStream();
+        verify(registeredScript, never()).getURL();
+    }
+
+    @Test
+    public void treatsBlankAndCustomAsTheTextareaScript() {
+        for (final String customURI : new String[] { null, "", "  ", GroovyConsoleHelper.CUSTOM_SCRIPT }) {
+            assertTrue("must be the custom script: " + customURI, GroovyConsoleHelper.isCustomScript(customURI));
+            assertNull(GroovyConsoleHelper.resolveScript(customURI));
+        }
+        assertFalse(GroovyConsoleHelper.isCustomScript(REGISTERED_URI));
+    }
+
+    @Test
+    public void readsNoConfigurationForAURITheRegistryDoesNotOffer() {
+        // The sibling .properties file is a second read derived from the same parameter, so it needs the same gate.
+        assertEquals("", GroovyConsoleHelper.getScriptCustomFormElements("file:///etc/passwd",
+                mock(HttpServletRequest.class)));
+        assertNull(GroovyConsoleHelper.getScriptParamNames(null));
+    }
+}


### PR DESCRIPTION
### Description
Restricted the Groovy console `scriptURI` parameter to the scripts packaged in active module bundles.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
